### PR TITLE
Kb/3673/uhd multi channel commands

### DIFF
--- a/host/examples/tx_from_file_crimson.cpp
+++ b/host/examples/tx_from_file_crimson.cpp
@@ -668,9 +668,6 @@ int UHD_SAFE_MAIN(int argc, char *argv[]){
     std::cout << boost::format("Creating the transmit crimson device with: %s...") % tx_args << std::endl;
     uhd::usrp::multi_usrp::sptr tx_usrp = uhd::usrp::multi_usrp::make(tx_args);
 
-    std::cout << boost::format("Creating the receive usrp device with: %s...") % rx_args << std::endl;
-    uhd::usrp::multi_usrp::sptr rx_usrp = uhd::usrp::multi_usrp::make(rx_args);
-
     //detect which channels to use
     std::vector<size_t> tx_channel_nums;
     for( std::string &n: input_stream_data.channels ) {
@@ -683,7 +680,6 @@ int UHD_SAFE_MAIN(int argc, char *argv[]){
     }
 
     std::cout << boost::format("Using Device: %s") % tx_usrp->get_pp_string() << std::endl;
-    std::cout << boost::format("Using Device: %s") % rx_usrp->get_pp_string() << std::endl;
 
     //set the transmit sample rate
     for( const auto& kv: input_stream_data.tx_sample_rate ) {

--- a/host/include/uhd/usrp/multi_crimson_tng.hpp
+++ b/host/include/uhd/usrp/multi_crimson_tng.hpp
@@ -219,6 +219,7 @@ private:
     fs_path tx_rf_fe_root(const size_t chan);
     fs_path tx_dsp_root(const size_t chan);
     fs_path tx_link_root(const size_t chan);
+    fs_path cm_root();
 };
 
 }}

--- a/host/lib/usrp/crimson_tng/crimson_tng_impl.cpp
+++ b/host/lib/usrp/crimson_tng/crimson_tng_impl.cpp
@@ -485,6 +485,7 @@ crimson_tng_impl::crimson_tng_impl(const device_addr_t &dev_addr)
 	const fs_path tx_dsp_path   = mb_path / "tx_dsps" / chan;
 	const fs_path rx_link_path  = mb_path / "rx_link" / chan;
 	const fs_path tx_link_path  = mb_path / "tx_link" / chan;
+	const fs_path cm_path  = mb_path / "cm";
 
         static const std::vector<std::string> antenna_options = boost::assign::list_of("SMA")("None");
         _tree->create<std::vector<std::string> >(rx_fe_path / "antenna" / "options").set(antenna_options);
@@ -603,6 +604,15 @@ crimson_tng_impl::crimson_tng_impl(const device_addr_t &dev_addr)
 	TREE_CREATE_RW(tx_link_path / "vita_en", "tx_"+lc_num+"/link/vita_en", std::string, string);
 	TREE_CREATE_RW(tx_link_path / "port",    "tx_"+lc_num+"/link/port",    std::string, string);
 	TREE_CREATE_RW(tx_link_path / "iface",   "tx_"+lc_num+"/link/iface",   std::string, string);
+
+	// Common Mode
+	TREE_CREATE_RW(cm_path / "chanmask-rx", "cm/chanmask-rx", int, int);
+	TREE_CREATE_RW(cm_path / "chanmask-tx", "cm/chanmask-tx", int, int);
+	TREE_CREATE_RW(cm_path / "rx/atten/val", "cm/rx/atten/val", double, double);
+	TREE_CREATE_RW(cm_path / "rx/gain/val", "cm/rx/gain/val", double, double);
+	TREE_CREATE_RW(cm_path / "tx/gain/val", "cm/tx/gain/val", double, double);
+	TREE_CREATE_RW(cm_path / "trx/freq/val", "cm/trx/freq/val", double, double);
+	TREE_CREATE_RW(cm_path / "trx/nco_adj", "cm/trx/nco_adj", double, double);
     }
 }
 

--- a/host/lib/usrp/crimson_tng/crimson_tng_impl.cpp
+++ b/host/lib/usrp/crimson_tng/crimson_tng_impl.cpp
@@ -486,13 +486,13 @@ crimson_tng_impl::crimson_tng_impl(const device_addr_t &dev_addr)
 		const fs_path rx_link_path  = mb_path / "rx_link" / chan;
 		const fs_path tx_link_path  = mb_path / "tx_link" / chan;
 
-			static const std::vector<std::string> antenna_options = boost::assign::list_of("SMA")("None");
-			_tree->create<std::vector<std::string> >(rx_fe_path / "antenna" / "options").set(antenna_options);
-			_tree->create<std::vector<std::string> >(tx_fe_path / "antenna" / "options").set(antenna_options);
+		static const std::vector<std::string> antenna_options = boost::assign::list_of("SMA")("None");
+		_tree->create<std::vector<std::string> >(rx_fe_path / "antenna" / "options").set(antenna_options);
+		_tree->create<std::vector<std::string> >(tx_fe_path / "antenna" / "options").set(antenna_options);
 
-			static const std::vector<std::string> sensor_options = boost::assign::list_of("lo_locked");
-			_tree->create<std::vector<std::string> >(rx_fe_path / "sensors").set(sensor_options);
-			_tree->create<std::vector<std::string> >(tx_fe_path / "sensors").set(sensor_options);
+		static const std::vector<std::string> sensor_options = boost::assign::list_of("lo_locked");
+		_tree->create<std::vector<std::string> >(rx_fe_path / "sensors").set(sensor_options);
+		_tree->create<std::vector<std::string> >(tx_fe_path / "sensors").set(sensor_options);
 
 		// Actual frequency values
 		TREE_CREATE_RW(rx_path / chan / "freq" / "value", "rx_"+lc_num+"/rf/freq/val", double, double);
@@ -555,7 +555,7 @@ crimson_tng_impl::crimson_tng_impl(const device_addr_t &dev_addr)
 		TREE_CREATE_RW(tx_fe_path / "freq"  / "value", "tx_"+lc_num+"/rf/freq/val" , double, double);
 		TREE_CREATE_RW(tx_fe_path / "gain"  / "value", "tx_"+lc_num+"/rf/gain/val" , double, double);
 
-	   // RF band
+		// RF band
 		TREE_CREATE_RW(rx_fe_path / "freq" / "band", "rx_"+lc_num+"/rf/freq/band", int, int);
 		TREE_CREATE_RW(tx_fe_path / "freq" / "band", "tx_"+lc_num+"/rf/freq/band", int, int);
 

--- a/host/lib/usrp/crimson_tng/crimson_tng_impl.cpp
+++ b/host/lib/usrp/crimson_tng/crimson_tng_impl.cpp
@@ -472,138 +472,140 @@ crimson_tng_impl::crimson_tng_impl(const device_addr_t &dev_addr)
 
     // loop for all RF chains
     for (int chain = 0; chain < 4; chain ++) {
-	std::string lc_num  = boost::lexical_cast<std::string>((char)(chain + 97));
-	std::string num     = boost::lexical_cast<std::string>((char)(chain + 65));
-	std::string chan    = "Channel_" + num;
+		std::string lc_num  = boost::lexical_cast<std::string>((char)(chain + 97));
+		std::string num     = boost::lexical_cast<std::string>((char)(chain + 65));
+		std::string chan    = "Channel_" + num;
 
-	const fs_path rx_codec_path = mb_path / "rx_codecs" / num;
-	const fs_path tx_codec_path = mb_path / "tx_codecs" / num;
-	const fs_path rx_fe_path    = mb_path / "dboards" / num / "rx_frontends" / chan;
-	const fs_path tx_fe_path    = mb_path / "dboards" / num / "tx_frontends" / chan;
-	const fs_path db_path       = mb_path / "dboards" / num;
-	const fs_path rx_dsp_path   = mb_path / "rx_dsps" / chan;
-	const fs_path tx_dsp_path   = mb_path / "tx_dsps" / chan;
-	const fs_path rx_link_path  = mb_path / "rx_link" / chan;
-	const fs_path tx_link_path  = mb_path / "tx_link" / chan;
+		const fs_path rx_codec_path = mb_path / "rx_codecs" / num;
+		const fs_path tx_codec_path = mb_path / "tx_codecs" / num;
+		const fs_path rx_fe_path    = mb_path / "dboards" / num / "rx_frontends" / chan;
+		const fs_path tx_fe_path    = mb_path / "dboards" / num / "tx_frontends" / chan;
+		const fs_path db_path       = mb_path / "dboards" / num;
+		const fs_path rx_dsp_path   = mb_path / "rx_dsps" / chan;
+		const fs_path tx_dsp_path   = mb_path / "tx_dsps" / chan;
+		const fs_path rx_link_path  = mb_path / "rx_link" / chan;
+		const fs_path tx_link_path  = mb_path / "tx_link" / chan;
+
+			static const std::vector<std::string> antenna_options = boost::assign::list_of("SMA")("None");
+			_tree->create<std::vector<std::string> >(rx_fe_path / "antenna" / "options").set(antenna_options);
+			_tree->create<std::vector<std::string> >(tx_fe_path / "antenna" / "options").set(antenna_options);
+
+			static const std::vector<std::string> sensor_options = boost::assign::list_of("lo_locked");
+			_tree->create<std::vector<std::string> >(rx_fe_path / "sensors").set(sensor_options);
+			_tree->create<std::vector<std::string> >(tx_fe_path / "sensors").set(sensor_options);
+
+		// Actual frequency values
+		TREE_CREATE_RW(rx_path / chan / "freq" / "value", "rx_"+lc_num+"/rf/freq/val", double, double);
+		TREE_CREATE_RW(tx_path / chan / "freq" / "value", "tx_"+lc_num+"/rf/freq/val", double, double);
+
+		// Power status
+		TREE_CREATE_RW(rx_path / chan / "pwr", "rx_"+lc_num+"/pwr", std::string, string);
+		TREE_CREATE_RW(tx_path / chan / "pwr", "tx_"+lc_num+"/pwr", std::string, string);
+
+		// Channel Stream Status
+		TREE_CREATE_RW(rx_link_path / "stream", "rx_"+lc_num+"/stream", std::string, string);
+
+		// Codecs, phony properties for Crimson
+		TREE_CREATE_RW(rx_codec_path / "gains", "rx_"+lc_num+"/dsp/gain", int, int);
+		TREE_CREATE_ST(rx_codec_path / "name", std::string, "RX Codec");
+
+		TREE_CREATE_RW(tx_codec_path / "gains", "tx_"+lc_num+"/dsp/gain", int, int);
+		TREE_CREATE_ST(tx_codec_path / "name", std::string, "TX Codec");
+
+		// Daughter Boards' Frontend Settings
+		TREE_CREATE_ST(rx_fe_path / "name",   std::string, "RX Board");
+		TREE_CREATE_ST(tx_fe_path / "name",   std::string, "TX Board");
+
+		TREE_CREATE_ST(rx_fe_path / "gains" / "LMH+PE" / "range", meta_range_t,
+			meta_range_t(CRIMSON_TNG_RF_RX_GAIN_RANGE_START, CRIMSON_TNG_RF_RX_GAIN_RANGE_STOP, CRIMSON_TNG_RF_RX_GAIN_RANGE_STEP));
+		TREE_CREATE_ST(tx_fe_path / "gains" / "PE" / "range",	meta_range_t,
+			meta_range_t(CRIMSON_TNG_RF_TX_GAIN_RANGE_START, CRIMSON_TNG_RF_TX_GAIN_RANGE_STOP, CRIMSON_TNG_RF_TX_GAIN_RANGE_STEP));
+
+		TREE_CREATE_ST(rx_fe_path / "freq", meta_range_t,
+			meta_range_t(CRIMSON_TNG_FREQ_RANGE_START, CRIMSON_TNG_FREQ_RANGE_STOP, CRIMSON_TNG_FREQ_RANGE_STEP));
+		TREE_CREATE_ST(tx_fe_path / "freq", meta_range_t,
+			meta_range_t(CRIMSON_TNG_FREQ_RANGE_START, CRIMSON_TNG_FREQ_RANGE_STOP, CRIMSON_TNG_FREQ_RANGE_STEP));
+
+		TREE_CREATE_ST(rx_fe_path / "dc_offset" / "enable", bool, false);
+		TREE_CREATE_ST(rx_fe_path / "dc_offset" / "value", std::complex<double>, std::complex<double>(0.0, 0.0));
+		TREE_CREATE_ST(rx_fe_path / "iq_balance" / "value", std::complex<double>, std::complex<double>(0.0, 0.0));
+
+		TREE_CREATE_ST(tx_fe_path / "dc_offset" / "value", std::complex<double>, std::complex<double>(0.0, 0.0));
+		TREE_CREATE_ST(tx_fe_path / "iq_balance" / "value", std::complex<double>, std::complex<double>(0.0, 0.0));
+
+		TREE_CREATE_RW(rx_fe_path / "connection",  "rx_"+lc_num+"/link/iface", std::string, string);
+		TREE_CREATE_RW(tx_fe_path / "connection",  "tx_"+lc_num+"/link/iface", std::string, string);
+
+		TREE_CREATE_ST(rx_fe_path / "use_lo_offset", bool, false);
+		TREE_CREATE_ST(tx_fe_path / "use_lo_offset", bool, false);
+		TREE_CREATE_RW(tx_fe_path / "lo_offset" / "value", "tx_"+lc_num+"/rf/dac/nco", double, double);
+
+		TREE_CREATE_ST(tx_fe_path / "freq" / "range", meta_range_t,
+			meta_range_t(CRIMSON_TNG_FREQ_RANGE_START, CRIMSON_TNG_FREQ_RANGE_STOP, CRIMSON_TNG_FREQ_RANGE_STEP));
+		TREE_CREATE_ST(rx_fe_path / "freq" / "range", meta_range_t,
+			meta_range_t(CRIMSON_TNG_FREQ_RANGE_START, CRIMSON_TNG_FREQ_RANGE_STOP, CRIMSON_TNG_FREQ_RANGE_STEP));
+		TREE_CREATE_ST(rx_fe_path / "gain" / "range", meta_range_t,
+			meta_range_t(CRIMSON_TNG_RF_RX_GAIN_RANGE_START, CRIMSON_TNG_RF_RX_GAIN_RANGE_STOP, CRIMSON_TNG_RF_RX_GAIN_RANGE_STEP));
+		TREE_CREATE_ST(tx_fe_path / "gain" / "range", meta_range_t,
+			meta_range_t(CRIMSON_TNG_RF_TX_GAIN_RANGE_START, CRIMSON_TNG_RF_TX_GAIN_RANGE_STOP, CRIMSON_TNG_RF_TX_GAIN_RANGE_STEP));
+
+		TREE_CREATE_RW(rx_fe_path / "freq"  / "value", "rx_"+lc_num+"/rf/freq/val" , double, double);
+		TREE_CREATE_RW(rx_fe_path / "gain"  / "value", "rx_"+lc_num+"/rf/gain/val" , double, double);
+		TREE_CREATE_RW(rx_fe_path / "atten" / "value", "rx_"+lc_num+"/rf/atten/val", double, double);
+		TREE_CREATE_RW(tx_fe_path / "freq"  / "value", "tx_"+lc_num+"/rf/freq/val" , double, double);
+		TREE_CREATE_RW(tx_fe_path / "gain"  / "value", "tx_"+lc_num+"/rf/gain/val" , double, double);
+
+	   // RF band
+		TREE_CREATE_RW(rx_fe_path / "freq" / "band", "rx_"+lc_num+"/rf/freq/band", int, int);
+		TREE_CREATE_RW(tx_fe_path / "freq" / "band", "tx_"+lc_num+"/rf/freq/band", int, int);
+
+		// RF receiver LNA
+		TREE_CREATE_RW(rx_fe_path / "freq"  / "lna", "rx_"+lc_num+"/rf/freq/lna" , int, int);
+
+		// these are phony properties for Crimson
+		TREE_CREATE_ST(db_path / "rx_eeprom",  dboard_eeprom_t, dboard_eeprom_t());
+		TREE_CREATE_ST(db_path / "tx_eeprom",  dboard_eeprom_t, dboard_eeprom_t());
+		TREE_CREATE_ST(db_path / "gdb_eeprom", dboard_eeprom_t, dboard_eeprom_t());
+
+		// DSPs
+		TREE_CREATE_ST(rx_dsp_path / "rate" / "range", meta_range_t,
+			meta_range_t(CRIMSON_TNG_RATE_RANGE_START, CRIMSON_TNG_RATE_RANGE_STOP, CRIMSON_TNG_RATE_RANGE_STEP));
+		TREE_CREATE_ST(rx_dsp_path / "freq" / "range", meta_range_t,
+			meta_range_t(CRIMSON_TNG_DSP_FREQ_RANGE_START, CRIMSON_TNG_DSP_FREQ_RANGE_STOP, CRIMSON_TNG_DSP_FREQ_RANGE_STEP));
+		TREE_CREATE_ST(rx_dsp_path / "bw" / "range",   meta_range_t,
+			meta_range_t(CRIMSON_TNG_RATE_RANGE_START, CRIMSON_TNG_RATE_RANGE_STOP, CRIMSON_TNG_RATE_RANGE_STEP));
+		TREE_CREATE_ST(tx_dsp_path / "rate" / "range", meta_range_t,
+			meta_range_t(CRIMSON_TNG_RATE_RANGE_START, CRIMSON_TNG_RATE_RANGE_STOP, CRIMSON_TNG_RATE_RANGE_STEP));
+		TREE_CREATE_ST(tx_dsp_path / "freq" / "range", meta_range_t,
+			meta_range_t(CRIMSON_TNG_DSP_FREQ_RANGE_START, CRIMSON_TNG_DSP_FREQ_RANGE_STOP, CRIMSON_TNG_DSP_FREQ_RANGE_STEP));
+		TREE_CREATE_ST(tx_dsp_path / "bw" / "range",   meta_range_t,
+			meta_range_t(CRIMSON_TNG_RATE_RANGE_START, CRIMSON_TNG_RATE_RANGE_STOP, CRIMSON_TNG_RATE_RANGE_STEP));
+
+		TREE_CREATE_RW(rx_dsp_path / "rate" / "value", "rx_"+lc_num+"/dsp/rate",    double, double);
+		TREE_CREATE_RW(rx_dsp_path / "freq" / "value", "rx_"+lc_num+"/dsp/nco_adj", double, double);
+		TREE_CREATE_RW(rx_dsp_path / "bw" / "value",   "rx_"+lc_num+"/dsp/rate",    double, double);
+		//TREE_CREATE_ST(rx_dsp_path / "stream_cmd",     stream_cmd_t, (stream_cmd_t)0);
+
+		TREE_CREATE_RW(tx_dsp_path / "rate" / "value", "tx_"+lc_num+"/dsp/rate",    double, double);
+		TREE_CREATE_RW(tx_dsp_path / "freq" / "value", "tx_"+lc_num+"/dsp/nco_adj", double, double);
+		TREE_CREATE_RW(tx_dsp_path / "bw" / "value",   "tx_"+lc_num+"/dsp/rate",    double, double);
+
+		TREE_CREATE_RW(rx_dsp_path / "nco", "rx_"+lc_num+"/dsp/nco_adj", double, double);
+		TREE_CREATE_RW(tx_dsp_path / "nco", "tx_"+lc_num+"/dsp/nco_adj", double, double);
+		TREE_CREATE_RW(tx_fe_path / "nco", "tx_"+lc_num+"/rf/dac/nco", double, double);
+
+		// Link settings
+		TREE_CREATE_RW(rx_link_path / "vita_en", "rx_"+lc_num+"/link/vita_en", std::string, string);
+		TREE_CREATE_RW(rx_link_path / "ip_dest", "rx_"+lc_num+"/link/ip_dest", std::string, string);
+		TREE_CREATE_RW(rx_link_path / "port",    "rx_"+lc_num+"/link/port",    std::string, string);
+		TREE_CREATE_RW(rx_link_path / "iface",   "rx_"+lc_num+"/link/iface",   std::string, string);
+
+		TREE_CREATE_RW(tx_link_path / "vita_en", "tx_"+lc_num+"/link/vita_en", std::string, string);
+		TREE_CREATE_RW(tx_link_path / "port",    "tx_"+lc_num+"/link/port",    std::string, string);
+		TREE_CREATE_RW(tx_link_path / "iface",   "tx_"+lc_num+"/link/iface",   std::string, string);
+    }
+
 	const fs_path cm_path  = mb_path / "cm";
-
-        static const std::vector<std::string> antenna_options = boost::assign::list_of("SMA")("None");
-        _tree->create<std::vector<std::string> >(rx_fe_path / "antenna" / "options").set(antenna_options);
-        _tree->create<std::vector<std::string> >(tx_fe_path / "antenna" / "options").set(antenna_options);
-
-        static const std::vector<std::string> sensor_options = boost::assign::list_of("lo_locked");
-        _tree->create<std::vector<std::string> >(rx_fe_path / "sensors").set(sensor_options);
-        _tree->create<std::vector<std::string> >(tx_fe_path / "sensors").set(sensor_options);
-
-	// Actual frequency values
-	TREE_CREATE_RW(rx_path / chan / "freq" / "value", "rx_"+lc_num+"/rf/freq/val", double, double);
-	TREE_CREATE_RW(tx_path / chan / "freq" / "value", "tx_"+lc_num+"/rf/freq/val", double, double);
-
-	// Power status
-	TREE_CREATE_RW(rx_path / chan / "pwr", "rx_"+lc_num+"/pwr", std::string, string);
-	TREE_CREATE_RW(tx_path / chan / "pwr", "tx_"+lc_num+"/pwr", std::string, string);
-
-	// Channel Stream Status
-	TREE_CREATE_RW(rx_link_path / "stream", "rx_"+lc_num+"/stream", std::string, string);
-
-	// Codecs, phony properties for Crimson
-	TREE_CREATE_RW(rx_codec_path / "gains", "rx_"+lc_num+"/dsp/gain", int, int);
-	TREE_CREATE_ST(rx_codec_path / "name", std::string, "RX Codec");
-
-	TREE_CREATE_RW(tx_codec_path / "gains", "tx_"+lc_num+"/dsp/gain", int, int);
-	TREE_CREATE_ST(tx_codec_path / "name", std::string, "TX Codec");
-
-	// Daughter Boards' Frontend Settings
-	TREE_CREATE_ST(rx_fe_path / "name",   std::string, "RX Board");
-	TREE_CREATE_ST(tx_fe_path / "name",   std::string, "TX Board");
-
-	TREE_CREATE_ST(rx_fe_path / "gains" / "LMH+PE" / "range", meta_range_t,
-		meta_range_t(CRIMSON_TNG_RF_RX_GAIN_RANGE_START, CRIMSON_TNG_RF_RX_GAIN_RANGE_STOP, CRIMSON_TNG_RF_RX_GAIN_RANGE_STEP));
-	TREE_CREATE_ST(tx_fe_path / "gains" / "PE" / "range",	meta_range_t,
-		meta_range_t(CRIMSON_TNG_RF_TX_GAIN_RANGE_START, CRIMSON_TNG_RF_TX_GAIN_RANGE_STOP, CRIMSON_TNG_RF_TX_GAIN_RANGE_STEP));
-
-	TREE_CREATE_ST(rx_fe_path / "freq", meta_range_t,
-		meta_range_t(CRIMSON_TNG_FREQ_RANGE_START, CRIMSON_TNG_FREQ_RANGE_STOP, CRIMSON_TNG_FREQ_RANGE_STEP));
-	TREE_CREATE_ST(tx_fe_path / "freq", meta_range_t,
-		meta_range_t(CRIMSON_TNG_FREQ_RANGE_START, CRIMSON_TNG_FREQ_RANGE_STOP, CRIMSON_TNG_FREQ_RANGE_STEP));
-
-	TREE_CREATE_ST(rx_fe_path / "dc_offset" / "enable", bool, false);
-	TREE_CREATE_ST(rx_fe_path / "dc_offset" / "value", std::complex<double>, std::complex<double>(0.0, 0.0));
-	TREE_CREATE_ST(rx_fe_path / "iq_balance" / "value", std::complex<double>, std::complex<double>(0.0, 0.0));
-
-	TREE_CREATE_ST(tx_fe_path / "dc_offset" / "value", std::complex<double>, std::complex<double>(0.0, 0.0));
-	TREE_CREATE_ST(tx_fe_path / "iq_balance" / "value", std::complex<double>, std::complex<double>(0.0, 0.0));
-
-	TREE_CREATE_RW(rx_fe_path / "connection",  "rx_"+lc_num+"/link/iface", std::string, string);
-	TREE_CREATE_RW(tx_fe_path / "connection",  "tx_"+lc_num+"/link/iface", std::string, string);
-
-	TREE_CREATE_ST(rx_fe_path / "use_lo_offset", bool, false);
-	TREE_CREATE_ST(tx_fe_path / "use_lo_offset", bool, false);
-	TREE_CREATE_RW(tx_fe_path / "lo_offset" / "value", "tx_"+lc_num+"/rf/dac/nco", double, double);
-
-	TREE_CREATE_ST(tx_fe_path / "freq" / "range", meta_range_t,
-		meta_range_t(CRIMSON_TNG_FREQ_RANGE_START, CRIMSON_TNG_FREQ_RANGE_STOP, CRIMSON_TNG_FREQ_RANGE_STEP));
-	TREE_CREATE_ST(rx_fe_path / "freq" / "range", meta_range_t,
-		meta_range_t(CRIMSON_TNG_FREQ_RANGE_START, CRIMSON_TNG_FREQ_RANGE_STOP, CRIMSON_TNG_FREQ_RANGE_STEP));
-	TREE_CREATE_ST(rx_fe_path / "gain" / "range", meta_range_t,
-		meta_range_t(CRIMSON_TNG_RF_RX_GAIN_RANGE_START, CRIMSON_TNG_RF_RX_GAIN_RANGE_STOP, CRIMSON_TNG_RF_RX_GAIN_RANGE_STEP));
-	TREE_CREATE_ST(tx_fe_path / "gain" / "range", meta_range_t,
-		meta_range_t(CRIMSON_TNG_RF_TX_GAIN_RANGE_START, CRIMSON_TNG_RF_TX_GAIN_RANGE_STOP, CRIMSON_TNG_RF_TX_GAIN_RANGE_STEP));
-
-	TREE_CREATE_RW(rx_fe_path / "freq"  / "value", "rx_"+lc_num+"/rf/freq/val" , double, double);
-	TREE_CREATE_RW(rx_fe_path / "gain"  / "value", "rx_"+lc_num+"/rf/gain/val" , double, double);
-	TREE_CREATE_RW(rx_fe_path / "atten" / "value", "rx_"+lc_num+"/rf/atten/val", double, double);
-	TREE_CREATE_RW(tx_fe_path / "freq"  / "value", "tx_"+lc_num+"/rf/freq/val" , double, double);
-	TREE_CREATE_RW(tx_fe_path / "gain"  / "value", "tx_"+lc_num+"/rf/gain/val" , double, double);
-
-   // RF band
-	TREE_CREATE_RW(rx_fe_path / "freq" / "band", "rx_"+lc_num+"/rf/freq/band", int, int);
-	TREE_CREATE_RW(tx_fe_path / "freq" / "band", "tx_"+lc_num+"/rf/freq/band", int, int);
-
-	// RF receiver LNA
-	TREE_CREATE_RW(rx_fe_path / "freq"  / "lna", "rx_"+lc_num+"/rf/freq/lna" , int, int);
-
-	// these are phony properties for Crimson
-	TREE_CREATE_ST(db_path / "rx_eeprom",  dboard_eeprom_t, dboard_eeprom_t());
-	TREE_CREATE_ST(db_path / "tx_eeprom",  dboard_eeprom_t, dboard_eeprom_t());
-	TREE_CREATE_ST(db_path / "gdb_eeprom", dboard_eeprom_t, dboard_eeprom_t());
-
-	// DSPs
-	TREE_CREATE_ST(rx_dsp_path / "rate" / "range", meta_range_t,
-		meta_range_t(CRIMSON_TNG_RATE_RANGE_START, CRIMSON_TNG_RATE_RANGE_STOP, CRIMSON_TNG_RATE_RANGE_STEP));
-	TREE_CREATE_ST(rx_dsp_path / "freq" / "range", meta_range_t,
-		meta_range_t(CRIMSON_TNG_DSP_FREQ_RANGE_START, CRIMSON_TNG_DSP_FREQ_RANGE_STOP, CRIMSON_TNG_DSP_FREQ_RANGE_STEP));
-	TREE_CREATE_ST(rx_dsp_path / "bw" / "range",   meta_range_t,
-		meta_range_t(CRIMSON_TNG_RATE_RANGE_START, CRIMSON_TNG_RATE_RANGE_STOP, CRIMSON_TNG_RATE_RANGE_STEP));
-	TREE_CREATE_ST(tx_dsp_path / "rate" / "range", meta_range_t,
-		meta_range_t(CRIMSON_TNG_RATE_RANGE_START, CRIMSON_TNG_RATE_RANGE_STOP, CRIMSON_TNG_RATE_RANGE_STEP));
-	TREE_CREATE_ST(tx_dsp_path / "freq" / "range", meta_range_t,
-		meta_range_t(CRIMSON_TNG_DSP_FREQ_RANGE_START, CRIMSON_TNG_DSP_FREQ_RANGE_STOP, CRIMSON_TNG_DSP_FREQ_RANGE_STEP));
-	TREE_CREATE_ST(tx_dsp_path / "bw" / "range",   meta_range_t,
-		meta_range_t(CRIMSON_TNG_RATE_RANGE_START, CRIMSON_TNG_RATE_RANGE_STOP, CRIMSON_TNG_RATE_RANGE_STEP));
-
-	TREE_CREATE_RW(rx_dsp_path / "rate" / "value", "rx_"+lc_num+"/dsp/rate",    double, double);
-	TREE_CREATE_RW(rx_dsp_path / "freq" / "value", "rx_"+lc_num+"/dsp/nco_adj", double, double);
-	TREE_CREATE_RW(rx_dsp_path / "bw" / "value",   "rx_"+lc_num+"/dsp/rate",    double, double);
-	//TREE_CREATE_ST(rx_dsp_path / "stream_cmd",     stream_cmd_t, (stream_cmd_t)0);
-
-	TREE_CREATE_RW(tx_dsp_path / "rate" / "value", "tx_"+lc_num+"/dsp/rate",    double, double);
-	TREE_CREATE_RW(tx_dsp_path / "freq" / "value", "tx_"+lc_num+"/dsp/nco_adj", double, double);
-	TREE_CREATE_RW(tx_dsp_path / "bw" / "value",   "tx_"+lc_num+"/dsp/rate",    double, double);
-
-	TREE_CREATE_RW(rx_dsp_path / "nco", "rx_"+lc_num+"/dsp/nco_adj", double, double);
-	TREE_CREATE_RW(tx_dsp_path / "nco", "tx_"+lc_num+"/dsp/nco_adj", double, double);
-	TREE_CREATE_RW(tx_fe_path / "nco", "tx_"+lc_num+"/rf/dac/nco", double, double);
-
-	// Link settings
-	TREE_CREATE_RW(rx_link_path / "vita_en", "rx_"+lc_num+"/link/vita_en", std::string, string);
-	TREE_CREATE_RW(rx_link_path / "ip_dest", "rx_"+lc_num+"/link/ip_dest", std::string, string);
-	TREE_CREATE_RW(rx_link_path / "port",    "rx_"+lc_num+"/link/port",    std::string, string);
-	TREE_CREATE_RW(rx_link_path / "iface",   "rx_"+lc_num+"/link/iface",   std::string, string);
-
-	TREE_CREATE_RW(tx_link_path / "vita_en", "tx_"+lc_num+"/link/vita_en", std::string, string);
-	TREE_CREATE_RW(tx_link_path / "port",    "tx_"+lc_num+"/link/port",    std::string, string);
-	TREE_CREATE_RW(tx_link_path / "iface",   "tx_"+lc_num+"/link/iface",   std::string, string);
 
 	// Common Mode
 	TREE_CREATE_RW(cm_path / "chanmask-rx", "cm/chanmask-rx", int, int);
@@ -613,7 +615,6 @@ crimson_tng_impl::crimson_tng_impl(const device_addr_t &dev_addr)
 	TREE_CREATE_RW(cm_path / "tx/gain/val", "cm/tx/gain/val", double, double);
 	TREE_CREATE_RW(cm_path / "trx/freq/val", "cm/trx/freq/val", double, double);
 	TREE_CREATE_RW(cm_path / "trx/nco_adj", "cm/trx/nco_adj", double, double);
-    }
 }
 
 crimson_tng_impl::~crimson_tng_impl(void)

--- a/host/lib/usrp/crimson_tng/io_tng_impl.cpp
+++ b/host/lib/usrp/crimson_tng/io_tng_impl.cpp
@@ -379,11 +379,24 @@ private:
 		_max_clock_ppm_error = 100;
 
 		for (unsigned int i = 0; i < _channels.size(); i++) {
+
+			std::string sfp;
+			switch( _channels[ i ] ) {
+			case 0:
+			case 2:
+				sfp = "sfpa";
+				break;
+			case 1:
+			case 3:
+				sfp = "sfpb";
+				break;
+			}
+
 			std::string ch       = boost::lexical_cast<std::string>((char)(_channels[i] + 65));
 			std::string udp_port = tree->access<std::string>(prop_path / "Channel_"+ch / "port").get();
 			std::string iface    = tree->access<std::string>(prop_path / "Channel_"+ch / "iface").get();
-			std::string ip_addr  = tree->access<std::string>( mb_path / "link" / iface / "ip_addr").get();
-			_pay_len = tree->access<int>(mb_path / "link" / iface / "pay_len").get();
+			std::string ip_addr  = tree->access<std::string>( mb_path / "link" / sfp / "ip_addr").get();
+			_pay_len = tree->access<int>(mb_path / "link" / sfp / "pay_len").get();
 
 			// power on the channel
 			tree->access<std::string>(mb_path / "tx" / "Channel_"+ch / "pwr").set("1");


### PR DESCRIPTION
This change is mostly self-evident.

There are some indentation changes, just to make things easier on the eyes.

The addition of 'sfp' in io_tng_impl.cpp was required to get tx_streamer to work.

Otherwise, the changes were mostly to check if either chanmask-rx or chanmask-tx was 0, to write to the regular file, if so, otherwise to the appropriate common mode property.