### PR TITLE
Kb/3690/libuhd device argument for multi channel parameter sync

### DIFF
--- a/host/lib/usrp/crimson_tng/io_tng_impl.cpp
+++ b/host/lib/usrp/crimson_tng/io_tng_impl.cpp
@@ -393,7 +393,7 @@ private:
 		_channels = _channels.empty() ? std::vector<size_t>(1, 0) : _channels;
 
 		if ( addr.has_key( "sync_multichannel_params" ) && "1" == addr[ "sync_multichannel_params" ] ) {
-			tree->access<int>( mb_path / "cm" / "chanmask-rx" ).set( channels_to_mask( _channels ) );
+			tree->access<int>( mb_path / "cm" / "chanmask-tx" ).set( channels_to_mask( _channels ) );
 		}
 
 		//Set up mutex variables


### PR DESCRIPTION
Must be merged after #8 

Add device_addr_t key-value pair to enable rx and tx Common Mode.
   
Upon instantiation of the Crimson TNG device via the UHD API, if the key-value pair "sync_multichannel_params":"1" is passed within the device_addr_t dictionary type, then whenever an associated crimson_tng_rx_streamer or crimson_tng_tx_streamer class is initialized, it's channel mask is set according to the channels that are active in that streamer class and it may be used in Common Mode.
    
In Common Mode, any common parameters (those listed under "/cm/") will affect all channels concurrently that are masked.