### PR TITLE
Kb/3772/uhd reimplement multi crimson get time now

### DIFF
--- a/host/examples/tx_from_file_crimson.cpp
+++ b/host/examples/tx_from_file_crimson.cpp
@@ -37,6 +37,9 @@ using namespace std;
 static std::map<const std::string,int> to = { { "A", 0 }, { "B", 1 }, { "C", 2 }, { "D", 3 } };
 static std::map<int,const std::string> fro = { { 0, "A" }, { 1, "B" }, { 2, "C" }, { 3, "D" } };
 
+/*
+// XXX: @CF: kb #3773
+
 //
 // <SNIP src="http://archive.oreilly.com/network/2003/05/06/examples/calculatorexample.html">
 //
@@ -260,6 +263,8 @@ private:
 // </SNIP>
 //
 
+*/
+
 /***********************************************************************
  * StreamData Class for buffering data for several channels at once from file
  *
@@ -325,9 +330,12 @@ public:
 
 		std::ifstream fs( fn );
 
+		/*
+		 // XXX: @CF: kb #3773
 		symtab_t variables;
 		calculator calc( variables );
 		variables["pi"] = 3.141592653589792;
+		*/
 
 		for( lineno = 0; ; lineno++ ) {
 			std::getline( (std::istream&) fs, line );
@@ -346,25 +354,33 @@ public:
 
 			case 1:
 				for( unsigned i = 0; i < r.n_channels; i++ ) {
-					r.rx_center_freq[ r.channels[ i ] ] = calc.crunch( split[ i ] );
+					// XXX: @CF: kb #3773
+					//r.rx_center_freq[ r.channels[ i ] ] = calc.crunch( split[ i ] );
+					r.rx_center_freq[ r.channels[ i ] ] = stod( split[ i ] );
 				}
 				break;
 
 			case 2:
 				for( unsigned i = 0; i < r.n_channels; i++ ) {
-					r.tx_center_freq[ r.channels[ i ] ] = calc.crunch( split[ i ] );
+					// XXX: @CF: kb #3773
+					//r.tx_center_freq[ r.channels[ i ] ] = calc.crunch( split[ i ] );
+					r.tx_center_freq[ r.channels[ i ] ] = stod( split[ i ] );
 				}
 				break;
 
 			case 3:
 				for( unsigned i = 0; i < r.n_channels; i++ ) {
-					r.rx_sample_rate[ r.channels[ i ] ] = calc.crunch( split[ i ] );
+					// XXX: @CF: kb #3773
+					//r.rx_sample_rate[ r.channels[ i ] ] = calc.crunch( split[ i ] );
+					r.rx_sample_rate[ r.channels[ i ] ] = stod( split[ i ] );
 				}
 				break;
 
 			case 4:
 				for( unsigned i = 0; i < r.n_channels; i++ ) {
-					r.tx_sample_rate[ r.channels[ i ] ] = calc.crunch( split[ i ] );
+					// XXX: @CF: kb #3773
+					//r.tx_sample_rate[ r.channels[ i ] ] = calc.crunch( split[ i ] );
+					r.tx_sample_rate[ r.channels[ i ] ] = stod( split[ i ] );
 				}
 				break;
 

--- a/host/examples/txrx_loopback_to_from_file_crimson.cpp
+++ b/host/examples/txrx_loopback_to_from_file_crimson.cpp
@@ -37,6 +37,7 @@ using namespace std;
 static std::map<const std::string,int> to = { { "A", 0 }, { "B", 1 }, { "C", 2 }, { "D", 3 } };
 static std::map<int,const std::string> fro = { { 0, "A" }, { 1, "B" }, { 2, "C" }, { 3, "D" } };
 
+/*
 //
 // <SNIP src="http://archive.oreilly.com/network/2003/05/06/examples/calculatorexample.html">
 //
@@ -260,6 +261,8 @@ private:
 // </SNIP>
 //
 
+*/
+
 /***********************************************************************
  * StreamData Class for buffering data for several channels at once from file
  *
@@ -325,9 +328,12 @@ public:
 
 		std::ifstream fs( fn );
 
+		/*
+		 // XXX: @CF: kb #3773
 		symtab_t variables;
 		calculator calc( variables );
 		variables["pi"] = 3.141592653589792;
+		*/
 
 		for( lineno = 0; ; lineno++ ) {
 			std::getline( (std::istream&) fs, line );
@@ -346,25 +352,33 @@ public:
 
 			case 1:
 				for( unsigned i = 0; i < r.n_channels; i++ ) {
-					r.rx_center_freq[ r.channels[ i ] ] = calc.crunch( split[ i ] );
+					// XXX: @CF: kb #3773
+					//r.rx_center_freq[ r.channels[ i ] ] = calc.crunch( split[ i ] );
+					r.rx_center_freq[ r.channels[ i ] ] = stod( split[ i ] );
 				}
 				break;
 
 			case 2:
 				for( unsigned i = 0; i < r.n_channels; i++ ) {
-					r.tx_center_freq[ r.channels[ i ] ] = calc.crunch( split[ i ] );
+					// XXX: @CF: kb #3773
+					//r.tx_center_freq[ r.channels[ i ] ] = calc.crunch( split[ i ] );
+					r.tx_center_freq[ r.channels[ i ] ] = stod( split[ i ] );
 				}
 				break;
 
 			case 3:
 				for( unsigned i = 0; i < r.n_channels; i++ ) {
-					r.rx_sample_rate[ r.channels[ i ] ] = calc.crunch( split[ i ] );
+					// XXX: @CF: kb #3773
+					//r.rx_sample_rate[ r.channels[ i ] ] = calc.crunch( split[ i ] );
+					r.rx_sample_rate[ r.channels[ i ] ] = stod( split[ i ] );
 				}
 				break;
 
 			case 4:
 				for( unsigned i = 0; i < r.n_channels; i++ ) {
-					r.tx_sample_rate[ r.channels[ i ] ] = calc.crunch( split[ i ] );
+					// XXX: @CF: kb #3773
+					//r.tx_sample_rate[ r.channels[ i ] ] = calc.crunch( split[ i ] );
+					r.tx_sample_rate[ r.channels[ i ] ] = stod( split[ i ] );
 				}
 				break;
 

--- a/host/lib/usrp/crimson_tng/crimson_tng_impl.hpp
+++ b/host/lib/usrp/crimson_tng/crimson_tng_impl.hpp
@@ -137,7 +137,7 @@ private:
     boost::mutex _async_mutex;
     std::vector<int> _async_comm;
 
-    double _time_diff; // measured in seconds
+    double _time_diff = 0; // measured in seconds
 };
 
 #endif /* INCLUDED_CRIMSON_TNG_IMPL_HPP */

--- a/host/lib/usrp/crimson_tng/crimson_tng_impl.hpp
+++ b/host/lib/usrp/crimson_tng/crimson_tng_impl.hpp
@@ -82,8 +82,8 @@ public:
 
     uhd::device_addr_t _addr;
 
-    double get_time_diff();
-    void set_time_diff( double time_diff );
+    inline double get_time_diff() { return _time_diff; }
+    void set_time_diff( double time_diff ) { _time_diff = time_diff; }
 
 private:
     // helper functions to wrap send and recv as get and set
@@ -137,7 +137,7 @@ private:
     boost::mutex _async_mutex;
     std::vector<int> _async_comm;
 
-    double time_diff; // measured in seconds
+    double _time_diff; // measured in seconds
 };
 
 #endif /* INCLUDED_CRIMSON_TNG_IMPL_HPP */

--- a/host/lib/usrp/crimson_tng/crimson_tng_impl.hpp
+++ b/host/lib/usrp/crimson_tng/crimson_tng_impl.hpp
@@ -82,6 +82,9 @@ public:
 
     uhd::device_addr_t _addr;
 
+    double get_time_diff();
+    void set_time_diff( double time_diff );
+
 private:
     // helper functions to wrap send and recv as get and set
     std::string get_string(std::string req);
@@ -133,6 +136,8 @@ private:
     boost::mutex _udp_mutex;
     boost::mutex _async_mutex;
     std::vector<int> _async_comm;
+
+    double time_diff; // measured in seconds
 };
 
 #endif /* INCLUDED_CRIMSON_TNG_IMPL_HPP */

--- a/host/lib/usrp/multi_crimson_tng.cpp
+++ b/host/lib/usrp/multi_crimson_tng.cpp
@@ -196,7 +196,7 @@ std::string multi_crimson_tng::get_mboard_name(size_t mboard){
 // Get the current time on Crimson
 time_spec_t multi_crimson_tng::get_time_now(size_t mboard){
 	crimson_tng_impl::sptr dev = boost::static_pointer_cast<crimson_tng_impl>( this->_dev );
-	return time_spec_t::get_system_time().get_real_secs() + dev->get_time_diff();
+	return time_spec_t( time_spec_t::get_system_time().get_real_secs() + dev->get_time_diff() );
 }
 
 // Get the time of the last PPS (pulse per second)

--- a/host/lib/usrp/multi_crimson_tng.cpp
+++ b/host/lib/usrp/multi_crimson_tng.cpp
@@ -36,6 +36,7 @@
 #include <cmath>
 
 #include "crimson_tng/crimson_tng_fw_common.h"
+#include "crimson_tng/crimson_tng_impl.hpp"
 
 #define CRIMSON_MASTER_CLOCK_RATE	322265625
 #define CRIMSON_RX_CHANNELS 4
@@ -194,7 +195,8 @@ std::string multi_crimson_tng::get_mboard_name(size_t mboard){
 
 // Get the current time on Crimson
 time_spec_t multi_crimson_tng::get_time_now(size_t mboard){
-    return _tree->access<time_spec_t>(mb_root(0) / "time/now").get();
+	crimson_tng_impl::sptr dev = boost::static_pointer_cast<crimson_tng_impl>( this->_dev );
+	return time_spec_t::get_system_time().get_real_secs() + dev->get_time_diff();
 }
 
 // Get the time of the last PPS (pulse per second)


### PR DESCRIPTION
Merge after PR #11 

This implementation uses the uhd::device::get_time_now() interface.

If no crimson "Time Diff" packets have been sent, received, and processed,
then multi_crimson_tng::get_time_now() behaves identially to
time_spec_t::get_system_time().