### PR TITLE
Kb/3821/uhd fix sob integration issues

### DIFF
--- a/host/examples/tx_from_file_crimson.cpp
+++ b/host/examples/tx_from_file_crimson.cpp
@@ -613,22 +613,22 @@ void transmit_worker(
 
     sd.fillBuffers( tx_channel_nums, buffs, indeces );
 
+	double delay_s = 0.5;
+
+	metadata.has_time_spec = true;
+	metadata.time_spec = uhd::time_spec_t( tx_usrp->get_time_now().get_real_secs() + delay_s );
+
+	std::cout << "Sending " << sd.n_samples << " samples, " << delay_s << " s from now" << std::endl;
+
     //send data until the signal handler gets called
     while(not stop_signal_called){
-
-    	double delay_s = 5;
-
-    	metadata.has_time_spec = true;
-    	metadata.time_spec = uhd::time_spec_t( tx_usrp->get_time_now().get_real_secs() + delay_s );
-
-    	std::cout << "Sending " << sd.n_samples << " samples, " << delay_s << " s from now" << std::endl;
 
         //send the entire contents of the buffer
         size_t sent_samples = tx_streamer->send( buff_ptrs, sd.n_samples, metadata );
 //        std::cout << "sent " << sent_samples << " samples" << std::endl;
 
-//        metadata.start_of_burst = false;
-//        metadata.has_time_spec = false;
+        metadata.start_of_burst = false;
+        metadata.has_time_spec = false;
     }
 
     std::cout << "sending EOB" << std::endl;
@@ -724,7 +724,7 @@ int UHD_SAFE_MAIN(int argc, char *argv[]){
     	std::string chan = kv.first;
 		int chani = to[ chan ];
 
-        tx_gain = 31.75;
+        tx_gain = 20.0;
         std::cout << boost::format("Setting TX Gain: %f dB...") % tx_gain << std::endl;
     	tx_usrp->set_tx_gain( tx_gain, chani );
     	tx_gain = tx_usrp->get_tx_gain( chani );

--- a/host/lib/usrp/crimson_tng/io_tng_impl.cpp
+++ b/host/lib/usrp/crimson_tng/io_tng_impl.cpp
@@ -332,7 +332,7 @@ public:
 	size_t send(
         	const buffs_type &buffs,
         	const size_t nsamps_per_buff,
-        	const tx_metadata_t &metadata,
+        	const tx_metadata_t &_metadata,
         	const double timeout = 0.1)
 	{
 
@@ -343,6 +343,9 @@ public:
 		size_t bytes_sent = 0;
 		size_t remaining_bytes[_channels.size()];
 		vrt::if_packet_info_t if_packet_info;
+
+		// need r/w capabilities for 'has_time_spec'
+		tx_metadata_t metadata = _metadata;
 
 		for (unsigned int i = 0; i < _channels.size(); i++) {
 			remaining_bytes[i] =  (nsamps_per_buff * 4);

--- a/host/lib/usrp/multi_crimson_tng.cpp
+++ b/host/lib/usrp/multi_crimson_tng.cpp
@@ -200,7 +200,7 @@ time_spec_t multi_crimson_tng::get_time_now(size_t mboard){
 	crimson_tng_impl::sptr dev = boost::static_pointer_cast<crimson_tng_impl>( _dev );
 	double diff = NULL == dev.get() ? 0 : dev.get()->get_time_diff();
 	diff = std::abs( diff ) > 1 ? 0 : diff;
-	return time_spec_t( time_spec_t::get_system_time().get_real_secs() + diff );
+	return time_spec_t( time_spec_t::get_system_time().get_real_secs() - diff );
 }
 
 // Get the time of the last PPS (pulse per second)

--- a/host/lib/usrp/multi_crimson_tng.cpp
+++ b/host/lib/usrp/multi_crimson_tng.cpp
@@ -197,8 +197,10 @@ std::string multi_crimson_tng::get_mboard_name(size_t mboard){
 
 // Get the current time on Crimson
 time_spec_t multi_crimson_tng::get_time_now(size_t mboard){
-	crimson_tng_impl::sptr dev = boost::static_pointer_cast<crimson_tng_impl>( this->_dev );
-	return time_spec_t( time_spec_t::get_system_time().get_real_secs() + dev->get_time_diff() );
+	crimson_tng_impl::sptr dev = boost::static_pointer_cast<crimson_tng_impl>( _dev );
+	double diff = NULL == dev.get() ? 0 : dev.get()->get_time_diff();
+	diff = std::abs( diff ) > 1 ? 0 : diff;
+	return time_spec_t( time_spec_t::get_system_time().get_real_secs() + diff );
 }
 
 // Get the time of the last PPS (pulse per second)


### PR DESCRIPTION
1. clock convergence runs perpetually. (i.e. remove 'sob_pending')
2. Fix null ptr dereference in when waiting for clock domain synchronization
3. Changed crimson_tng_tx_streamer::send() to use the host's view of Crimson's clock, not the host clock, for timekeeping
4. '_last_time[]' computed for SoB, so that Crimson's buffers are primed before steady state
5. use usleep() if time until SoB is 'large', rather than busy-looping