### PR TITLE
Kb/3857/uhd correct rx gain ranges

### DIFF
--- a/host/lib/usrp/multi_crimson_tng.cpp
+++ b/host/lib/usrp/multi_crimson_tng.cpp
@@ -641,7 +641,7 @@ void multi_crimson_tng::set_rx_gain(double gain, const std::string &name, size_t
 			atten_val = 31.75;
 			// LMH is adjusted from 0dB to 31.5dB
 			gain_val = gain;
-		} else if ( 31.5 <= gain && gain <= 63.25 ) {
+		} else if ( 31.5 < gain && gain <= 63.25 ) {
 			// PMA is off (+0dB)
 			lna_val = 0;
 			// BFP is on (+20dB)
@@ -649,7 +649,7 @@ void multi_crimson_tng::set_rx_gain(double gain, const std::string &name, size_t
 			atten_val = 63.25 - gain;
 			// LMH is maxed (+31.5dB)
 			gain_val = 31.5;
-		} else if ( 63.25 <= gain && gain <= CRIMSON_TNG_RF_RX_GAIN_RANGE_STOP ) {
+		} else if ( 63.25 < gain && gain <= CRIMSON_TNG_RF_RX_GAIN_RANGE_STOP ) {
 			// PMA is on (+20dB)
 			lna_val = 20;
 			// BFP is on (+20dB)
@@ -661,7 +661,7 @@ void multi_crimson_tng::set_rx_gain(double gain, const std::string &name, size_t
 	}
 
 	int lna_bypass_enable = 0 == lna_val ? 1 : 0;
-	_tree->access<double>( rx_rf_fe_root(chan) / "freq" / "lna" ).set( lna_bypass_enable );
+	_tree->access<int>( rx_rf_fe_root(chan) / "freq" / "lna" ).set( lna_bypass_enable );
 
     if ( 0 == _tree->access<int>( cm_root() / "chanmask-rx" ).get() ) {
 		_tree->access<double>( rx_rf_fe_root(chan) / "atten" / "value" ).set( atten_val * 4 );
@@ -677,7 +677,7 @@ double multi_crimson_tng::get_rx_gain(const std::string &name, size_t chan){
 
 	double r;
 
-	bool lna_bypass_enable = 0 == _tree->access<double>(rx_rf_fe_root(chan) / "freq" / "lna").get() ? false : true;
+	bool lna_bypass_enable = 0 == _tree->access<int>(rx_rf_fe_root(chan) / "freq" / "lna").get() ? false : true;
     double lna_val = lna_bypass_enable ? 0 : 20;
     double gain_val  = _tree->access<double>(rx_rf_fe_root(chan) / "gain"  / "value").get() / 4;
     double atten_val = _tree->access<double>(rx_rf_fe_root(chan) / "atten" / "value").get() / 4;

--- a/host/lib/usrp/multi_crimson_tng.cpp
+++ b/host/lib/usrp/multi_crimson_tng.cpp
@@ -660,8 +660,8 @@ void multi_crimson_tng::set_rx_gain(double gain, const std::string &name, size_t
 		}
 	}
 
-	// XXX: @CF: NB: lna is actually for lna bypass. If 0, the lna is in use, if 1, then not in use
-	_tree->access<double>( rx_rf_fe_root(chan) / "freq" / "lna" ).set( 0 == lna_val ? 1 : 0 );
+	int lna_bypass_enable = 0 == lna_val ? 1 : 0;
+	_tree->access<double>( rx_rf_fe_root(chan) / "freq" / "lna" ).set( lna_bypass_enable );
 
     if ( 0 == _tree->access<int>( cm_root() / "chanmask-rx" ).get() ) {
 		_tree->access<double>( rx_rf_fe_root(chan) / "atten" / "value" ).set( atten_val * 4 );
@@ -677,8 +677,8 @@ double multi_crimson_tng::get_rx_gain(const std::string &name, size_t chan){
 
 	double r;
 
-	// XXX: @CF: NB: lna is actually for lna bypass. If 0, the lna is in use, if 1, then not in use
-    double lna_val = 0 == _tree->access<double>(rx_rf_fe_root(chan) / "freq" / "lna").get() ? 20 : 0;
+	bool lna_bypass_enable = 0 == _tree->access<double>(rx_rf_fe_root(chan) / "freq" / "lna").get() ? false : true;
+    double lna_val = lna_bypass_enable ? 0 : 20;
     double gain_val  = _tree->access<double>(rx_rf_fe_root(chan) / "gain"  / "value").get() / 4;
     double atten_val = _tree->access<double>(rx_rf_fe_root(chan) / "atten" / "value").get() / 4;
 

--- a/host/tests/CMakeLists.txt
+++ b/host/tests/CMakeLists.txt
@@ -38,6 +38,7 @@ SET(test_sources
     property_test.cpp
     ranges_test.cpp
     sid_t_test.cpp
+    set_rx_gain_test.cpp
     sma_test.cpp
     sph_recv_test.cpp
     sph_send_test.cpp

--- a/host/tests/set_rx_gain_test.cpp
+++ b/host/tests/set_rx_gain_test.cpp
@@ -1,0 +1,175 @@
+#include <boost/test/unit_test.hpp>
+
+#include <cstdlib>
+#include <iostream>
+
+#include <uhd/transport/vrt_if_packet.hpp>
+#include <boost/format.hpp>
+
+#include "../include/uhd/usrp/multi_usrp.hpp"
+
+using namespace uhd;
+using namespace usrp;
+
+struct usrp_dev {
+	multi_usrp::sptr usrp;
+	device::sptr dev;
+};
+
+#ifndef ARRAY_SIZE
+#define ARRAY_SIZE( x ) ((int)( sizeof( x ) / sizeof( (x)[ 0 ] ) ))
+#endif
+
+static double get_atten( device::sptr &dev ) {
+	double r = -1.0;
+	uhd::property_tree::sptr tree = dev->get_tree();
+	r = tree->access<double>( "/mboards/0/dboards/A/rx_frontends/Channel_A/atten/value" ).get();
+	return r;
+}
+
+static double get_gain( device::sptr &dev ) {
+	double r = -1.0;
+	uhd::property_tree::sptr tree = dev->get_tree();
+	r = tree->access<double>( "/mboards/0/dboards/A/rx_frontends/Channel_A/gain/value" ).get();
+	return r;
+}
+
+static int get_lna( device::sptr &dev ) {
+	int r = -1;
+	uhd::property_tree::sptr tree = dev->get_tree();
+	r = tree->access<int>( "/mboards/0/dboards/A/rx_frontends/Channel_A/freq/lna" ).get();
+	return r;
+}
+
+static int get_band( device::sptr &dev ) {
+	int r = -1;
+	uhd::property_tree::sptr tree = dev->get_tree();
+	r = tree->access<int>( "/mboards/0/dboards/A/rx_frontends/Channel_A/freq/band" ).get();
+	return r;
+}
+
+static void get_usrp_dev( struct usrp_dev *ud ) {
+	device_addr_t addr;
+	BOOST_REQUIRE_NE( (void *) NULL, (void *) ud );
+	ud->usrp = uhd::usrp::multi_usrp::make( addr );
+	BOOST_REQUIRE_NE( (void *) NULL, (void *) ud->usrp.get() );
+	ud->dev =  ud->usrp->get_device();
+	BOOST_REQUIRE_NE( (void *) NULL, ud->dev.get() );
+	// we are primarily interested in testing high-band rx gain
+	uhd::tune_request_t tune( 2400000000 );
+	ud->usrp->set_rx_freq( tune );
+	int band = get_band( ud->dev );
+	BOOST_REQUIRE_EQUAL( 1, band );
+}
+
+BOOST_AUTO_TEST_CASE( test_range_AB ) {
+	struct usrp_dev ud;
+	get_usrp_dev( & ud );
+
+	double probed_rx_gain[] = { -1.0, 0.0, 31.5, };
+
+	double expected_rx_gain[] = { 0.0, 0.0, 31.5, };
+	double actual_rx_gain[ ARRAY_SIZE( probed_rx_gain ) ];
+
+	// atten is maxed
+	double expected_atten[] = { 31.75*4, 31.75*4, 31.75*4, };
+	double actual_atten[ ARRAY_SIZE( probed_rx_gain ) ];
+
+	// lna is bypassed
+	int expected_lna[] = { 1, 1, 1, };
+	int actual_lna[ ARRAY_SIZE( probed_rx_gain ) ];
+
+	// gain is varied from 0 to 31.5
+	double expected_gain[] = { 0.0, 0.0, 31.5*4, };
+	double actual_gain[ ARRAY_SIZE( probed_rx_gain ) ];
+
+	for( int k = 0; k < ARRAY_SIZE( probed_rx_gain ); k++ ) {
+
+		ud.usrp->set_rx_gain( probed_rx_gain[ k ], "" );
+
+		actual_rx_gain[ k ] = ud.usrp->get_rx_gain();
+		actual_atten[ k ] = get_atten( ud.dev );
+		actual_gain[ k ] = get_gain( ud.dev );
+		actual_lna[ k ] = get_lna( ud.dev );
+
+		BOOST_CHECK_CLOSE( expected_rx_gain[ k ], actual_rx_gain[ k ], 0.01 );
+		BOOST_CHECK_CLOSE( expected_atten[ k ], actual_atten[ k ], 0.01 );
+		BOOST_CHECK_CLOSE( expected_gain[ k ], actual_gain[ k ], 0.01 );
+		BOOST_CHECK_EQUAL( expected_lna[ k ], actual_lna[ k ] );
+	}
+}
+
+BOOST_AUTO_TEST_CASE( test_range_BC ) {
+	struct usrp_dev ud;
+	get_usrp_dev( & ud );
+
+	double probed_rx_gain[] = { 31.75, 63.25, };
+
+	double expected_rx_gain[] = { 31.75, 63.25, };
+	double actual_rx_gain[ ARRAY_SIZE( probed_rx_gain ) ];
+
+	//  atten is varied from 31.75 to 0
+	double expected_atten[] = { 31.5*4, 0.0, };
+	double actual_atten[ ARRAY_SIZE( probed_rx_gain ) ];
+
+	// lna is bypassed
+	int expected_lna[] = { 1, 1, };
+	int actual_lna[ ARRAY_SIZE( probed_rx_gain ) ];
+
+	// gain is maxed
+	double expected_gain[] = { 31.5*4, 31.5*4, };
+	double actual_gain[ ARRAY_SIZE( probed_rx_gain ) ];
+
+	for( int k = 0; k < ARRAY_SIZE( probed_rx_gain ); k++ ) {
+
+		ud.usrp->set_rx_gain( probed_rx_gain[ k ], "" );
+
+		actual_rx_gain[ k ] = ud.usrp->get_rx_gain();
+		actual_atten[ k ] = get_atten( ud.dev );
+		actual_gain[ k ] = get_gain( ud.dev );
+		actual_lna[ k ] = get_lna( ud.dev );
+
+		BOOST_CHECK_CLOSE( expected_rx_gain[ k ], actual_rx_gain[ k ], 0.01 );
+		BOOST_CHECK_CLOSE( expected_atten[ k ], actual_atten[ k ], 0.01 );
+		BOOST_CHECK_CLOSE( expected_gain[ k ], actual_gain[ k ], 0.01 );
+		BOOST_CHECK_EQUAL( expected_lna[ k ], actual_lna[ k ] );
+	}
+}
+
+BOOST_AUTO_TEST_CASE( test_range_CD ) {
+	struct usrp_dev ud;
+	get_usrp_dev( & ud );
+
+	double probed_rx_gain[] = { 63.5, 83.25, };
+
+	double expected_rx_gain[] = { 63.5, 83.25, };
+	double actual_rx_gain[ ARRAY_SIZE( probed_rx_gain ) ];
+
+	// atten is varied from 20 to 0
+	double expected_atten[] = { 19.75*4, 0.0, };
+	double actual_atten[ ARRAY_SIZE( probed_rx_gain ) ];
+
+	// lna is not bypassed
+	int expected_lna[] = { 0, 0, };
+	int actual_lna[ ARRAY_SIZE( probed_rx_gain ) ];
+
+	// gain is maxed
+	double expected_gain[] = { 31.5*4, 31.5*4, };
+	double actual_gain[ ARRAY_SIZE( probed_rx_gain ) ];
+
+	for( int k = 0; k < ARRAY_SIZE( probed_rx_gain ); k++ ) {
+
+		ud.usrp->set_rx_gain( probed_rx_gain[ k ], "" );
+
+		actual_rx_gain[ k ] = ud.usrp->get_rx_gain();
+		actual_atten[ k ] = get_atten( ud.dev );
+		actual_gain[ k ] = get_gain( ud.dev );
+		actual_lna[ k ] = get_lna( ud.dev );
+
+		BOOST_CHECK_CLOSE( expected_rx_gain[ k ], actual_rx_gain[ k ], 0.01 );
+		BOOST_CHECK_CLOSE( expected_atten[ k ], actual_atten[ k ], 0.01 );
+		BOOST_CHECK_CLOSE( expected_gain[ k ], actual_gain[ k ], 0.01 );
+		BOOST_CHECK_EQUAL( expected_lna[ k ], actual_lna[ k ] );
+	}
+}
+


### PR DESCRIPTION
Problem was caused by usage of `_tree->access<double>` vs `_tree->access<int>` for "freq/lna" property.

Added unit tests, which all pass now.