### PR TITLE
Kb/3850/uhd speed up clock convergence

### DIFF
--- a/host/lib/usrp/crimson_tng/io_tng_impl.cpp
+++ b/host/lib/usrp/crimson_tng/io_tng_impl.cpp
@@ -644,7 +644,15 @@ private:
 		_en_fc=true;
 		_flowcontrol_thread = new boost::thread(init_flowcontrol, this);
 
-		for( ; ! _pid_converged; ) {
+		for(
+			time_spec_t time_then = uhd::time_spec_t::get_system_time(),
+			time_now = time_then
+			; ! _pid_converged;
+			time_now = uhd::time_spec_t::get_system_time()
+		) {
+			if ( (time_now - time_then).get_full_secs() > 20 ) {
+				throw runtime_error( "Clock domain synchronization taking unusually long. Are there more than 1 applications controlling Crimson?" );
+			}
 			usleep( 100000 );
 		}
 

--- a/host/lib/usrp/crimson_tng/io_tng_impl.cpp
+++ b/host/lib/usrp/crimson_tng/io_tng_impl.cpp
@@ -644,12 +644,8 @@ private:
 		_en_fc=true;
 		_flowcontrol_thread = new boost::thread(init_flowcontrol, this);
 
-		if ( 0 == _instance_num ) {
-			for( ; ! _pid_converged; ) {
-				UHD_MSG( status ) << "Waiting for clock domains to synchronize.." << std::endl;
-				sleep( 1 );
-			}
-			UHD_MSG( status ) << "Clock domains have synchronized." << std::endl;
+		for( ; ! _pid_converged; ) {
+			usleep( 100000 );
 		}
 
 		num_instances_lock.unlock();
@@ -1037,8 +1033,8 @@ private:
 	 */
 	static constexpr double PV_MAX_ERROR_FOR_CONVERGENCE = 100e-6;
 	static constexpr double CV_FILTER_WINDOW_S = 2;
-	static constexpr double DPV_FILTER_WINDOW_S = 5;
-	bool _pid_converged = false;
+	static constexpr double DPV_FILTER_WINDOW_S = 0.25;
+	static bool _pid_converged;
 	uhd::diff _pv_derivor;
 	uhd::sma _dpv_filter;
 	uhd::sma _cv_filter;
@@ -1051,6 +1047,7 @@ private:
 std::mutex crimson_tng_tx_streamer::num_instances_lock;
 size_t crimson_tng_tx_streamer::num_instances = 0;
 size_t crimson_tng_tx_streamer::instance_counter = 0;
+bool crimson_tng_tx_streamer::_pid_converged = false;
 
 /***********************************************************************
  * Async Data

--- a/host/lib/usrp/crimson_tng/io_tng_impl.cpp
+++ b/host/lib/usrp/crimson_tng/io_tng_impl.cpp
@@ -650,9 +650,11 @@ private:
 			; ! _pid_converged;
 			time_now = uhd::time_spec_t::get_system_time()
 		) {
+#ifndef DEBUG_START_OF_BURST
 			if ( (time_now - time_then).get_full_secs() > 20 ) {
 				throw runtime_error( "Clock domain synchronization taking unusually long. Are there more than 1 applications controlling Crimson?" );
 			}
+#endif
 			usleep( 100000 );
 		}
 


### PR DESCRIPTION
* Shrink DPV_FILTER_WINDOW_S from 5s down to 250 ms
* Wait a max of 20s before throwing an exception if pid has not converged. The exception warns to check for other applications controlling Crimson.