### PR TITLE
Kb/3899/uhd rewrite recv to be compatible with uhd api

### DIFF
--- a/host/lib/usrp/multi_crimson_tng.cpp
+++ b/host/lib/usrp/multi_crimson_tng.cpp
@@ -390,27 +390,18 @@ void multi_crimson_tng::clear_command_time(size_t mboard){
 }
 
 void multi_crimson_tng::issue_stream_cmd(const stream_cmd_t &stream_cmd, size_t chan){
-    // set register to start the stream
-    if( stream_cmd.stream_mode == stream_cmd_t::STREAM_MODE_START_CONTINUOUS) {
+    switch( stream_cmd.stream_mode ) {
+    case stream_cmd_t::STREAM_MODE_START_CONTINUOUS:
+    case stream_cmd_t::STREAM_MODE_NUM_SAMPS_AND_DONE:
+    case stream_cmd_t::STREAM_MODE_NUM_SAMPS_AND_MORE:
+    	// currently we do not differentiate between any kind of stream-enable
+    	_tree->access<std::string>(rx_link_root(chan) / "stream").set("1");
+    	break;
+    case stream_cmd_t::STREAM_MODE_STOP_CONTINUOUS:
+    default:
     	_tree->access<std::string>(rx_link_root(chan) / "stream").set("0");
-        _tree->access<std::string>(rx_link_root(chan) / "stream").set("1");
-
-    // set register to stop the stream
-    } else if (stream_cmd.stream_mode == stream_cmd_t::STREAM_MODE_STOP_CONTINUOUS) {
-        _tree->access<std::string>(rx_link_root(chan) / "stream").set("0");
-
-    } else if (stream_cmd.stream_mode == stream_cmd_t::STREAM_MODE_NUM_SAMPS_AND_DONE) {
-	// set register to wait for a stream cmd after num_samps
-	// not supported in Crimson
-
-    } else if (stream_cmd.stream_mode == stream_cmd_t::STREAM_MODE_NUM_SAMPS_AND_MORE) {
-	// set register to not wait for a stream cmd after num_samps
-	// not supported in Crimson
-
-    } else {
-        _tree->access<std::string>(rx_link_root(chan) / "stream").set("0");
+    	break;
     }
-    return;
 }
 
 void multi_crimson_tng::set_clock_config(const clock_config_t &clock_config, size_t mboard) {


### PR DESCRIPTION
Currently we do not support NUM_SAMPLES_AND_DONE or NUM_SAMPLES_AND_MORE, but
we should at least enable the stream and not ignore the command for the latter
two cases.

Previously, if recv() was called with nsamps_per_buff < vita packet_size,
we would return only nsamps_per_buff. Subsequent reads would start in the
middle of a vita packet, and we would mistakenly parse a non-existent vita
header.

This change ensures that we buffer remaining vita packet data when
nsamps_per_buff < vita packet_size and that we return that data and the
corresponding metadata upon subsequent reads.