### PR TITLE
Kb/3887/uhd destructor

### DIFF
--- a/host/examples/rx_multi_samples.cpp
+++ b/host/examples/rx_multi_samples.cpp
@@ -127,7 +127,7 @@ int UHD_SAFE_MAIN(int argc, char *argv[]){
 
     //create a receive streamer
     //linearly map channels (index0 = channel0, index1 = channel1, ...)
-    uhd::stream_args_t stream_args("sc16"); //complex shorts
+    uhd::stream_args_t stream_args("fc32"); //complex floats
     stream_args.channels = channel_nums;
     uhd::rx_streamer::sptr rx_stream = usrp->get_rx_stream(stream_args);
 
@@ -146,13 +146,13 @@ int UHD_SAFE_MAIN(int argc, char *argv[]){
     uhd::rx_metadata_t md;
 
     //allocate buffers to receive with samples (one buffer per channel)
-    const size_t samps_per_buff = 80; // rx_stream->get_max_num_samps();
-    std::vector<std::vector<std::complex<short> > > buffs(
-        usrp->get_rx_num_channels(), std::vector<std::complex<short> >(samps_per_buff)
+    const size_t samps_per_buff = rx_stream->get_max_num_samps();
+    std::vector<std::vector<std::complex<float> > > buffs(
+        usrp->get_rx_num_channels(), std::vector<std::complex<float> >(samps_per_buff)
     );
 
     //create a vector of pointers to point to each of the channel buffers
-    std::vector<std::complex<short> *> buff_ptrs;
+    std::vector<std::complex<float> *> buff_ptrs;
     for (size_t i = 0; i < buffs.size(); i++) buff_ptrs.push_back(&buffs[i].front());
 
     //the first call to recv() will block this many seconds before receiving

--- a/host/examples/rx_multi_samples.cpp
+++ b/host/examples/rx_multi_samples.cpp
@@ -127,7 +127,7 @@ int UHD_SAFE_MAIN(int argc, char *argv[]){
 
     //create a receive streamer
     //linearly map channels (index0 = channel0, index1 = channel1, ...)
-    uhd::stream_args_t stream_args("fc32"); //complex floats
+    uhd::stream_args_t stream_args("sc16"); //complex shorts
     stream_args.channels = channel_nums;
     uhd::rx_streamer::sptr rx_stream = usrp->get_rx_stream(stream_args);
 
@@ -146,13 +146,13 @@ int UHD_SAFE_MAIN(int argc, char *argv[]){
     uhd::rx_metadata_t md;
 
     //allocate buffers to receive with samples (one buffer per channel)
-    const size_t samps_per_buff = rx_stream->get_max_num_samps();
-    std::vector<std::vector<std::complex<float> > > buffs(
-        usrp->get_rx_num_channels(), std::vector<std::complex<float> >(samps_per_buff)
+    const size_t samps_per_buff = 80; // rx_stream->get_max_num_samps();
+    std::vector<std::vector<std::complex<short> > > buffs(
+        usrp->get_rx_num_channels(), std::vector<std::complex<short> >(samps_per_buff)
     );
 
     //create a vector of pointers to point to each of the channel buffers
-    std::vector<std::complex<float> *> buff_ptrs;
+    std::vector<std::complex<short> *> buff_ptrs;
     for (size_t i = 0; i < buffs.size(); i++) buff_ptrs.push_back(&buffs[i].front());
 
     //the first call to recv() will block this many seconds before receiving

--- a/host/lib/usrp/crimson_tng/io_tng_impl.cpp
+++ b/host/lib/usrp/crimson_tng/io_tng_impl.cpp
@@ -56,6 +56,9 @@
 #ifndef DEBUG_START_OF_BURST
 //#define DEBUG_START_OF_BURST 1
 #endif
+#ifndef DEBUG_RECV
+//#define DEBUG_RECV 1
+#endif
 
 using namespace uhd;
 using namespace uhd::usrp;
@@ -137,10 +140,6 @@ public:
 	void update_fifo_metadata( rx_metadata_t &meta, size_t n_samples ) {
 		meta.time_spec += time_spec_t::from_ticks( n_samples, _rate );
 	}
-
-#ifndef DEBUG_RECV
-//#define DEBUG_RECV 1
-#endif
 
 	size_t recv(
         	const buffs_type &buffs,

--- a/host/lib/usrp/crimson_tng/io_tng_impl.cpp
+++ b/host/lib/usrp/crimson_tng/io_tng_impl.cpp
@@ -25,6 +25,7 @@
 #include <vector>
 #include <mutex>
 
+#include <boost/range/numeric.hpp>
 #include <boost/thread/thread.hpp>
 #include <boost/format.hpp>
 #include <boost/bind.hpp>
@@ -137,6 +138,10 @@ public:
 		meta.time_spec += time_spec_t::from_ticks( n_samples, _rate );
 	}
 
+#ifndef DEBUG_RECV
+//#define DEBUG_RECV 1
+#endif
+
 	size_t recv(
         	const buffs_type &buffs,
         	const size_t nsamps_per_buff,
@@ -148,27 +153,51 @@ public:
 		const size_t vita_tlr = 1;
 		const size_t vita_pck = nsamps_per_buff + vita_hdr + vita_tlr;
 		size_t nbytes = 0;
+		size_t nsamples = 0;
+
+		double _timeout = timeout;
+
+#ifdef DEBUG_RECV
+		//UHD_MSG( status ) << __func__ << "( buffs: " << (void *) & buffs << ", nsamps_per_buff: " << nsamps_per_buff << ", metadata: " << (void *) & metadata << ", timeout: " << timeout << ", one_packet: " << one_packet << " )" << std::endl;
+
+		// XXX: do not timeout when debugging
+		_timeout = 1e6;
+
+		// XXX: use the following infinite loop to start a debugger session and attach to process at a known "entry point"
+		//static bool _true = true;
+		//do {
+		//	std::cout << "";
+		//} while( _true );
+#endif
 
 		// temp buffer: vita hdr + data
 		uint32_t vita_buf[vita_pck];
 
-		ssize_t fifo_level = _fifo[ 0 ].size();
+		std::vector<size_t> fifo_level( _channels.size() );
+		for( unsigned i = 0; i < _channels.size(); i++ ) {
+			fifo_level[ i ] = _fifo[ i ].size();
+		}
 
-		if ( fifo_level > 0 ) {
+		if ( 0 != boost::accumulate( fifo_level, 0 ) ) {
 
 			for( unsigned i = 0; i < _channels.size(); i++ ) {
 				for( unsigned j = 0; j < nsamps_per_buff * 4 && ! _fifo[ i ].empty(); j++ ) {
 					( (uint8_t *) buffs[ i ] )[ j ] = _fifo[ i ].front();
 					_fifo[ i ].pop();
 				}
+				nbytes = fifo_level[ i ] - _fifo[ 0 ].size();
+				nsamples = nbytes / 4;
+
+#ifdef DEBUG_RECV
+				UHD_MSG( status ) << __func__ << "():" << __LINE__ << ": POP [ " << (char)( i + 'A' ) << " ]: nbytes: " << nbytes << ", nsamples: " << nsamples << std::endl;
+#endif
 			}
 
 			metadata = _fifo_metadata;
 
-			size_t fifo_samples_received = ( fifo_level - _fifo[ 0 ].size() ) / 4;
-			update_fifo_metadata( _fifo_metadata, fifo_samples_received );
+			update_fifo_metadata( _fifo_metadata, nsamples );
 
-			return fifo_samples_received;
+			return nsamples * _channels.size();
 		}
 
 		// read from each connected stream and dump it into the buffs[i]
@@ -179,11 +208,16 @@ public:
 			memset(buffs[i], 0, nsamps_per_buff * 4);
 
 			// read in vita_pck*4 bytes to temp buffer
-			nbytes = _udp_stream[i] -> stream_in(vita_buf, vita_pck * 4, timeout);
+			nbytes = _udp_stream[i] -> stream_in(vita_buf, vita_pck * 4, _timeout);
 			if (nbytes == 0) {
 				metadata.error_code =rx_metadata_t::ERROR_CODE_TIMEOUT;
 				return 0;
 			}
+			nsamples = nbytes / 4 - (vita_hdr + vita_tlr);
+
+#ifdef DEBUG_RECV
+			UHD_MSG( status ) << __func__ << "():" << __LINE__ << ": STREAM [ " << (char)( i + 'A' ) << " ]: nbytes: " << nbytes << ", nsamples: " << nsamples << std::endl;
+#endif
 
 			// copy non-vita packets to buffs[0]
 			memcpy(buffs[i], vita_buf + vita_hdr , nsamps_per_buff * 4);
@@ -233,6 +267,7 @@ public:
 		uint32_t vb0 = boost::endian::big_to_native( vita_buf[ 0 ] );
 		size_t nbytes_payload = nbytes - (vita_hdr + vita_tlr) * 4;
 		size_t vita_payload_len_bytes = ( ( vb0 & 0xffff ) - (vita_hdr + vita_tlr) ) * 4;
+
 		if ( nbytes_payload < vita_payload_len_bytes ) {
 
 			// buffer the remainder of the vita payload that was not received
@@ -247,28 +282,33 @@ public:
 					remaining_vita_payload_len_bytes > 0;
 					remaining_vita_payload_len_bytes -= nb
 				) {
-					nb = _udp_stream[i] -> stream_in( vita_buf, std::min( sizeof( vita_buf ), remaining_vita_payload_len_bytes ), timeout );
+					nb = _udp_stream[i] -> stream_in( vita_buf, std::min( sizeof( vita_buf ), remaining_vita_payload_len_bytes ), _timeout );
 					if ( nb == 0 ) {
 						metadata.error_code =rx_metadata_t::ERROR_CODE_TIMEOUT;
 						return 0;
 					}
+
 					for( unsigned j = 0; j < nb; j++ ) {
-						_fifo[ i ].push( vita_buf[ j ] );
+						_fifo[ i ].push( ( (uint8_t *) vita_buf ) [ j ] );
 					}
 				}
 
 				// read the vita trailer (1 32-bit word)
-				nb = _udp_stream[i] -> stream_in( vita_buf, vita_tlr * 4, timeout );
+				nb = _udp_stream[i] -> stream_in( vita_buf, vita_tlr * 4, _timeout );
 				if ( nb != 4 ) {
 					metadata.error_code =rx_metadata_t::ERROR_CODE_TIMEOUT;
 					return 0;
 				}
+
+#ifdef DEBUG_RECV
+				UHD_MSG( status ) << __func__ << "():" << __LINE__ << ": PUSH [ " << (char)( i + 'A' ) << " ]: nbytes: " << vita_payload_len_bytes - nbytes_payload << ", nsamples: " << ( vita_payload_len_bytes - nbytes_payload ) / 4 << std::endl;
+#endif
 			}
 
 			update_fifo_metadata( _fifo_metadata, ( vita_payload_len_bytes - nbytes_payload ) / 4 );
 		}
 
-		return (nbytes / 4) - 5;		// removed the 5 VITA 32-bit words
+		return nsamples * _channels.size();		// removed the 5 VITA 32-bit words
 	}
 
 	void issue_stream_cmd(const stream_cmd_t &stream_cmd) {

--- a/host/lib/usrp/crimson_tng/io_tng_impl.cpp
+++ b/host/lib/usrp/crimson_tng/io_tng_impl.cpp
@@ -57,7 +57,7 @@
 //#define DEBUG_START_OF_BURST 1
 #endif
 #ifndef DEBUG_RECV
-//#define DEBUG_RECV 1
+#define DEBUG_RECV 1
 #endif
 
 using namespace uhd;
@@ -196,7 +196,7 @@ public:
 
 			update_fifo_metadata( _fifo_metadata, nsamples );
 
-			return nsamples * _channels.size();
+			return nsamples;
 		}
 
 		// read from each connected stream and dump it into the buffs[i]
@@ -307,7 +307,7 @@ public:
 			update_fifo_metadata( _fifo_metadata, ( vita_payload_len_bytes - nbytes_payload ) / 4 );
 		}
 
-		return nsamples * _channels.size();		// removed the 5 VITA 32-bit words
+		return nsamples;		// removed the 5 VITA 32-bit words
 	}
 
 	void issue_stream_cmd(const stream_cmd_t &stream_cmd) {


### PR DESCRIPTION
Pull #33 before this one.

The top-level UHD block in GNU Radio has a couple of backend tricks to get their parts to stop.

For rx, `issue_stream_cmd(::uhd::stream_cmd_t::STREAM_MODE_STOP_CONTINUOUS);`is called when a flow graph containing a uhd source is terminated.

For tx, an empty end-of-burst packet is called when a flow graph containing a uhd sink is terminated.

```
//Send an empty end-of-burst packet to end streaming.
    //Ending the burst avoids an underflow error on stop.
    bool
    usrp_sink_impl::stop(void)
    {
      _metadata.start_of_burst = false;
      _metadata.end_of_burst = true;
      _metadata.has_time_spec = false;
      _nitems_to_send = 0;

#ifdef GR_UHD_USE_STREAM_API
      if(_tx_stream)
        _tx_stream->send(gr_vector_const_void_star(_nchan), 0, _metadata, 1.0);
#else
      _dev->get_device()->send
        (gr_vector_const_void_star(_nchan), 0, _metadata,
         *_type, ::uhd::device::SEND_MODE_ONE_PACKET, 1.0);
#endif
      return true;
    }
```

The destructors are actually never called for either, unfortunately, which could indicate that we have a leak in our shared pointer references. One solution to this is to use a weak pointer in some select cases.

For some reason, the process still does not exit, not sure if that is a related bug.