### PR TITLE
use lockfile and pid system to kill old processes

### DIFF
--- a/host/lib/usrp/crimson_tng/crimson_tng_impl.cpp
+++ b/host/lib/usrp/crimson_tng/crimson_tng_impl.cpp
@@ -45,8 +45,6 @@ using namespace uhd::usrp;
 using namespace uhd::transport;
 namespace asio = boost::asio;
 
-static void destroy_other_processes_using_crimson();
-
 // This is a lock to prevent multiple threads from requesting commands from
 // the device at the same time. This is important in GNURadio, as they spawn
 // a new thread per block. If not protected, UDP commands would time out.
@@ -641,82 +639,10 @@ crimson_tng_impl::crimson_tng_impl(const device_addr_t &dev_addr)
 	TREE_CREATE_RW(cm_path / "tx/gain/val", "cm/tx/gain/val", double, double);
 	TREE_CREATE_RW(cm_path / "trx/freq/val", "cm/trx/freq/val", double, double);
 	TREE_CREATE_RW(cm_path / "trx/nco_adj", "cm/trx/nco_adj", double, double);
-
-
-	// kb 4001: stop-gap solution until kb #4000 is fixed!!!
-	destroy_other_processes_using_crimson();
 }
 
 crimson_tng_impl::~crimson_tng_impl(void)
 {
     // TODO send commands to mute all radio chains, mute everything
     // unlock the Crimson device to this process
-}
-
-// kb 4001: stop-gap solution until kb #4000 is fixed!!!
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <unistd.h>
-#include <dirent.h>
-#include <signal.h>
-
-#include <regex>
-
-static void destroy_other_processes_using_crimson() {
-
-	static const std::regex re( "^crimson-([1-9][0-9]*).lock$" );
-	DIR *dp;
-	std::string lock_file_name;
-	std::smatch match;
-	uint64_t pidn;
-	std::stringstream ss;
-	int fd;
-
-	dp = opendir( "/tmp" );
-	if ( NULL == dp ) {
-		throw runtime_error(
-			(
-				boost::format( "opendir: %s (%d)" )
-				% std::strerror( errno )
-				% errno
-			).str()
-		);
-	}
-
-	for( dirent *de = readdir( dp ); NULL != de; de = readdir( dp ) ) {
-		if ( DT_REG != de->d_type ) {
-			continue;
-		}
-		lock_file_name = std::string( de->d_name );
-		if ( ! std::regex_search( lock_file_name, match, re ) ) {
-			continue;
-		}
-
-		ss = std::stringstream( match.str( 1 ) );
-		ss >> pidn;
-
-		if ( 0 == kill( pid_t( pidn ), SIGKILL ) ) {
-			UHD_MSG( warning ) << "killed hung process " << pidn << std::endl;
-		}
-
-		lock_file_name = "/tmp/" + lock_file_name;
-		if ( 0 == remove( lock_file_name.c_str() ) ) {
-			UHD_MSG( warning ) << "removed stale lockfile " << lock_file_name << std::endl;
-		} else {
-			UHD_MSG( warning ) << "failed to remove stale lockfile " << lock_file_name << std::endl;
-		}
-	}
-	closedir( dp );
-
-	ss.clear();
-	ss << "/tmp/crimson-" << (uint64_t) getpid() << ".lock";
-
-	lock_file_name = ss.str();
-
-	fd = open( lock_file_name.c_str(), O_RDWR | O_CREAT );
-	if ( -1 == fd ) {
-		UHD_MSG( warning ) << "failed to create lockfile " << lock_file_name << ": " << strerror( errno ) << std::endl;
-	} else {
-		close( fd );
-	}
 }

--- a/host/lib/usrp/crimson_tng/io_tng_impl.cpp
+++ b/host/lib/usrp/crimson_tng/io_tng_impl.cpp
@@ -1354,7 +1354,7 @@ static void destroy_other_processes_using_crimson() {
 
 	lock_file_name = ss.str();
 
-	fd = open( lock_file_name.c_str(), O_RDWR | O_CREAT );
+	fd = creat( lock_file_name.c_str(), O_RDWR );
 	if ( -1 == fd ) {
 		UHD_MSG( warning ) << "failed to create lockfile " << lock_file_name << ": " << strerror( errno ) << std::endl;
 	} else {

--- a/host/lib/usrp/crimson_tng/io_tng_impl.cpp
+++ b/host/lib/usrp/crimson_tng/io_tng_impl.cpp
@@ -1355,9 +1355,7 @@ static void destroy_other_processes_using_crimson() {
 	lock_file_name = ss.str();
 
 	fd = creat( lock_file_name.c_str(), O_RDWR );
-	if ( -1 == fd ) {
-		UHD_MSG( warning ) << "failed to create lockfile " << lock_file_name << ": " << strerror( errno ) << std::endl;
-	} else {
+	if ( -1 != fd ) {
 		close( fd );
 	}
 }

--- a/host/lib/usrp/crimson_tng/io_tng_impl.cpp
+++ b/host/lib/usrp/crimson_tng/io_tng_impl.cpp
@@ -70,6 +70,9 @@ namespace asio = boost::asio;
 namespace pt = boost::posix_time;
 namespace trans = uhd::transport;
 
+// kb 4001: stop-gap solution until kb #4000 is fixed!!!
+static void destroy_other_processes_using_crimson();
+
 static int channels_to_mask( std::vector<size_t> channels ) {
 	unsigned mask = 0;
 
@@ -638,6 +641,9 @@ public:
 private:
 	// init function, common to both constructors
 	void init_tx_streamer( device_addr_t addr, property_tree::sptr tree, std::vector<size_t> channels,boost::mutex* udp_mutex_add, std::vector<int>* async_comm, boost::mutex* async_mutex) {
+
+		// kb 4001: stop-gap solution until kb #4000 is fixed!!!
+		destroy_other_processes_using_crimson();
 
 		// kb #3850: we only instantiate / converge the PID controller for the 0th txstreamer instance
 		// to prevent any other constructors from returning before the PID is locked, surround the entire
@@ -1278,4 +1284,80 @@ tx_streamer::sptr crimson_tng_impl::get_tx_stream(const uhd::stream_args_t &args
 	crimson_tng_tx_streamer::sptr r( new crimson_tng_tx_streamer(this->_addr, this->_tree, args.channels, &this->_udp_mutex, &this->_async_comm, &this->_async_mutex) );
 	r->set_device( this );
 	return r;
+}
+
+// kb 4001: stop-gap solution until kb #4000 is fixed!!!
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <dirent.h>
+#include <signal.h>
+
+#include <regex>
+
+static void destroy_other_processes_using_crimson() {
+
+	static const std::regex re( "^crimson-([1-9][0-9]*).lock$" );
+	DIR *dp;
+	std::string lock_file_name;
+	std::smatch match;
+	uint64_t pidn;
+	std::stringstream ss;
+	int fd;
+
+	dp = opendir( "/tmp" );
+	if ( NULL == dp ) {
+		throw runtime_error(
+			(
+				boost::format( "opendir: %s (%d)" )
+				% std::strerror( errno )
+				% errno
+			).str()
+		);
+	}
+
+	for( dirent *de = readdir( dp ); NULL != de; de = readdir( dp ) ) {
+
+		if ( DT_REG != de->d_type ) {
+			continue;
+		}
+
+		lock_file_name = std::string( de->d_name );
+
+		if ( ! std::regex_search( lock_file_name, match, re ) ) {
+			continue;
+		}
+
+		ss = std::stringstream( match.str( 1 ) );
+		ss >> pidn;
+
+		if ( getpid() == pid_t( pidn ) ) {
+			// skip this PID, if an existing tx streamer has already been made
+			continue;
+		}
+
+		if ( 0 == kill( pid_t( pidn ), SIGKILL ) ) {
+			UHD_MSG( warning ) << "killed hung process " << pidn << std::endl;
+		}
+
+		lock_file_name = "/tmp/" + lock_file_name;
+		if ( 0 == remove( lock_file_name.c_str() ) ) {
+			UHD_MSG( warning ) << "removed stale lockfile " << lock_file_name << std::endl;
+		} else {
+			UHD_MSG( warning ) << "failed to remove stale lockfile " << lock_file_name << std::endl;
+		}
+	}
+	closedir( dp );
+
+	ss.clear();
+	ss << "/tmp/crimson-" << (uint64_t) getpid() << ".lock";
+
+	lock_file_name = ss.str();
+
+	fd = open( lock_file_name.c_str(), O_RDWR | O_CREAT );
+	if ( -1 == fd ) {
+		UHD_MSG( warning ) << "failed to create lockfile " << lock_file_name << ": " << strerror( errno ) << std::endl;
+	} else {
+		close( fd );
+	}
 }

--- a/host/lib/usrp/crimson_tng/io_tng_impl.cpp
+++ b/host/lib/usrp/crimson_tng/io_tng_impl.cpp
@@ -1294,7 +1294,6 @@ tx_streamer::sptr crimson_tng_impl::get_tx_stream(const uhd::stream_args_t &args
 #include <signal.h>
 
 #include <regex>
-#include <mutex>
 
 static void destroy_other_processes_using_crimson() {
 
@@ -1306,7 +1305,6 @@ static void destroy_other_processes_using_crimson() {
 	std::stringstream ss;
 	int fd;
 	struct stat st;
-	static std::mutex mt;
 
 	dp = opendir( "/tmp" );
 	if ( NULL == dp ) {


### PR DESCRIPTION
Upon instantiation of usrp, examines if other lockfiles exist in /tmp, kills the PIDs if they do exist, removes lockfiles, and then creates a new lockfile. Does not kill its own PID (in the case that a separate tx streamer thread has already been created in the same process). Only creates lock file for tx, not for rx, in the case where separate usrp devices are instantiated for rx and tx. will not work when there are multiple crimsons in use!

```
UHD Warning:
    killed hung process 9520

UHD Warning:
    removed stale lockfile /tmp/crimson-9520.lock
```