### PR TITLE
Fix a few bugs in TX Streamer Send

### DIFF
--- a/host/examples/tx_from_file_crimson.cpp
+++ b/host/examples/tx_from_file_crimson.cpp
@@ -388,7 +388,7 @@ public:
 				sampleno = lineno - 5;
 				sampleno /= 2;
 
-				r.n_samples = sampleno;
+				r.n_samples = sampleno + 1;
 
 				for( unsigned i = 0; i < r.n_channels; i++ ) {
 
@@ -586,96 +586,32 @@ static bool stop_signal_called = false;
 void sig_int_handler(int){stop_signal_called = true;}
 
 /***********************************************************************
- * transmit_worker function
- * A function to be used as a boost::thread_group thread for transmitting
- **********************************************************************/
-void transmit_worker(
-	StreamData &sd,
-	uhd::usrp::multi_usrp::sptr tx_usrp,
-    uhd::tx_streamer::sptr tx_streamer,
-    uhd::tx_metadata_t metadata,
-    std::vector<size_t> tx_channel_nums
-){
-	if ( sd.n_channels != tx_channel_nums.size() ) {
-		throw new uhd::runtime_error( "number of channels not consistent" );
-	}
-
-	std::vector<size_t> indeces( tx_channel_nums.size() );
-
-	std::vector< std::vector< std::complex< short > > > buffs( tx_channel_nums.size() );
-
-	sd.sizeBuffers( buffs );
-
-    std::vector< std::complex< short > * > buff_ptrs;
-    for( unsigned i = 0; i < buffs.size(); i++ ) {
-    	buff_ptrs.push_back( (std::complex<short int> * const &) & buffs[ i ].front() );
-    }
-
-    sd.fillBuffers( tx_channel_nums, buffs, indeces );
-
-	double delay_s = 0.5;
-
-	metadata.has_time_spec = true;
-	metadata.time_spec = uhd::time_spec_t( tx_usrp->get_time_now().get_real_secs() + delay_s );
-
-	std::cout << "Sending " << sd.n_samples << " samples, " << delay_s << " s from now" << std::endl;
-
-    //send data until the signal handler gets called
-    while(not stop_signal_called){
-
-        //send the entire contents of the buffer
-        size_t sent_samples = tx_streamer->send( buff_ptrs, sd.n_samples, metadata );
-//        std::cout << "sent " << sent_samples << " samples" << std::endl;
-
-        metadata.start_of_burst = false;
-        metadata.has_time_spec = false;
-    }
-
-    std::cout << "sending EOB" << std::endl;
-
-    //send a mini EOB packet
-    metadata.end_of_burst = true;
-    tx_streamer->send("", 0, metadata);
-}
-
-
-/***********************************************************************
  * Main function
  **********************************************************************/
 int UHD_SAFE_MAIN(int argc, char *argv[]){
     uhd::set_thread_priority_safe();
 
     //transmit variables to be set by po
-    std::string tx_args, wave_type, tx_ant, tx_subdev, ref, otw, tx_channels;
+    std::string tx_args, tx_channels;
     double tx_rate, tx_freq, tx_gain;
+    bool loop;
+    double sob;
 
     //receive variables to be set by po
-    std::string rx_args, input_fn, output_fn, type, rx_ant, rx_subdev, rx_channels;
-    double rx_rate, rx_freq;
-    float settling;
-    float rxtime;
-    size_t rxsamp;
+    std::string input_fn;
 
     //setup the program options
     po::options_description desc("Allowed options");
     desc.add_options()
         ("help", "help message")
         ("tx-args", po::value<std::string>(&tx_args)->default_value(""), "uhd transmit device address args")
-        ("rx-args", po::value<std::string>(&rx_args)->default_value(""), "uhd receive device address args")
         ("input", po::value<std::string>(&input_fn)->default_value("input.csv"), "name of the input file")
-		("output", po::value<std::string>(&output_fn)->default_value("output.csv"), "name of the output file")
-        ("settling", po::value<float>(&settling)->default_value(1), "settling time (seconds) before receiving")
-        ("rxtime", po::value<float>(&rxtime)->default_value(1), "maximum receive time (seconds)")
-        ("rxsamp", po::value<size_t>(&rxsamp)->default_value( DEFAULT_SAMPLE_LIMIT ), "maximum number of received samples")
+		("loop", po::value<bool>(&loop)->default_value( false ), "retransmit the signal in a loop")
+		("sob", po::value<double>(&sob)->default_value( 3 ), "delay transmission for sob seconds")
     ;
     po::variables_map vm;
     po::store(po::parse_command_line(argc, argv, desc), vm);
     po::notify(vm);
-
-    if ( rxtime < 0 ) {
-        std::cerr << boost::format("rxtime %f invalid") % rxtime << std::endl;
-        return ~0;
-    }
 
     //print the help message
     if (vm.count("help")){
@@ -689,7 +625,6 @@ int UHD_SAFE_MAIN(int argc, char *argv[]){
     StreamData::fromFile( input_stream_data, input_fn );
 
     //create a usrp device
-    std::cout << boost::format("Creating the transmit crimson device with: %s...") % tx_args << std::endl;
     uhd::usrp::multi_usrp::sptr tx_usrp = uhd::usrp::multi_usrp::make(tx_args);
 
     //detect which channels to use
@@ -698,12 +633,9 @@ int UHD_SAFE_MAIN(int argc, char *argv[]){
         tx_channel_nums.push_back( to[ n ] );
     }
 
-    std::vector<size_t> rx_channel_nums;
-    for( std::string &n: input_stream_data.channels ) {
-        rx_channel_nums.push_back( to[ n ] );
-    }
-
-    std::cout << boost::format("Using Device: %s") % tx_usrp->get_pp_string() << std::endl;
+	if ( input_stream_data.n_channels != tx_channel_nums.size() ) {
+		throw new uhd::runtime_error( "number of channels not consistent" );
+	}
 
     //set the transmit center frequency
     for( const auto& kv: input_stream_data.tx_center_freq ) {
@@ -749,34 +681,74 @@ int UHD_SAFE_MAIN(int argc, char *argv[]){
     //create a transmit streamer
     uhd::stream_args_t stream_args( "sc16", "sc16" );
     stream_args.channels = tx_channel_nums;
+    std::cout << "Getting TX Streamer.." << std::endl;
     uhd::tx_streamer::sptr tx_stream = tx_usrp->get_tx_stream( stream_args );
-
-    //setup the metadata flags
-    uhd::tx_metadata_t md;
-    md.start_of_burst = true;
-    md.end_of_burst   = false;
-    md.has_time_spec  = true;
-    md.time_spec = uhd::time_spec_t(0.1); //give us 0.1 seconds to fill the tx buffers
+    std::cout << "Got TX Streamer.." << std::endl;
 
 	std::signal(SIGINT, &sig_int_handler);
 	std::cout << "Press Ctrl + C to stop streaming..." << std::endl;
 
-	/*
-    XXX: @CF: Setting device timestamp to an arbitrary value (such as zero) can negatively
-    	 affect Crimson TNG time synchronization. The user is strongly discouraged from doing so.
-    */
-    //reset usrp time to prepare for transmit/receive
-	// std::cout << boost::format("Setting device timestamp to 0...") << std::endl;
-	// tx_usrp->set_time_now(uhd::time_spec_t(0.0));
+	std::vector<size_t> indeces( tx_channel_nums.size() );
 
-    //start transmit worker thread
-    boost::thread_group transmit_thread;
-    transmit_thread.create_thread( boost::bind( &transmit_worker, input_stream_data, tx_usrp, tx_stream, md, tx_channel_nums ) );
+	std::vector< std::vector< std::complex< short > > > buffs( tx_channel_nums.size() );
 
-    //clean up transmit worker
-    //stop_signal_called = true;
+	input_stream_data.sizeBuffers( buffs );
 
-    transmit_thread.join_all();
+    std::vector< std::complex< short > * > buff_ptrs;
+    for( unsigned i = 0; i < buffs.size(); i++ ) {
+    	buff_ptrs.push_back( (std::complex<short int> * const &) & buffs[ i ].front() );
+    }
+
+    input_stream_data.fillBuffers( tx_channel_nums, buffs, indeces );
+
+    //setup the metadata flags
+    uhd::tx_metadata_t md;
+
+    //send data until the signal handler gets called
+    for( ;; ) {
+
+        md.start_of_burst = true;
+        md.end_of_burst   = false;
+        if ( sob > 0 ) {
+    		md.has_time_spec = true;
+
+    		uhd::time_spec_t now = tx_usrp->get_time_now();
+    		uhd::time_spec_t then = now + sob;
+
+    		std::cout << "Now: " << std::setprecision(10) << now.get_real_secs() << std::endl;
+    		std::cout << "SoB: " << std::setprecision(10) << then.get_real_secs() << std::endl;
+
+    		md.time_spec = then;
+        } else {
+        	sob = 0;
+        	md.has_time_spec = false;
+        }
+
+        std::cout << "Sending " << input_stream_data.n_samples << " samples, " << sob << " s from now" << std::endl;
+
+        //send the entire contents of the buffer
+        tx_stream->send( buff_ptrs, input_stream_data.n_samples, md );
+
+//        if ( 0 == sob ) {
+//            std::cout << "Sending " << input_stream_data.n_samples << " samples, " << sob << " s from now" << std::endl;
+//			md.start_of_burst = false;
+//			md.has_time_spec = false;
+//        }
+
+        if ( ! loop ) {
+        	break;
+        }
+
+        if ( stop_signal_called ) {
+        	break;
+        }
+    }
+
+    std::cout << "sending EOB" << std::endl;
+
+    //send a mini EOB packet
+    md.end_of_burst = true;
+    tx_stream->send("", 0, md);
 
     //finished
     std::cout << std::endl << "Done!" << std::endl << std::endl;

--- a/host/lib/usrp/crimson_tng/crimson_tng_fw_common.h
+++ b/host/lib/usrp/crimson_tng/crimson_tng_fw_common.h
@@ -64,9 +64,9 @@ extern "C" {
 #define CRIMSON_TNG_FW_COMMS_FLAGS_PEEK32     (1 << 3)
 
 // Crimson min MTU size (empirically set mtu for QoS, udp header is 8 bytes)
-#define CRIMSON_TNG_MIN_MTU		(6400 - 8)
+#define CRIMSON_TNG_MIN_MTU		(6400 - 96)
 // Crimson max MTU size (jumbo ethernet frame is 9000 bytes)
-#define CRIMSON_TNG_MAX_MTU		(9000 - 8)
+#define CRIMSON_TNG_MAX_MTU		(9000 - 96)
 
 // Crimson Flowcontrol Update Per Second
 #define CRIMSON_TNG_UPDATE_PER_SEC	150

--- a/host/lib/usrp/crimson_tng/io_tng_impl.cpp
+++ b/host/lib/usrp/crimson_tng/io_tng_impl.cpp
@@ -17,6 +17,7 @@
 
 #include <algorithm>
 #include <cinttypes>
+#include <cmath>
 #include <cstdio>
 #include <iomanip>
 #include <iostream>
@@ -82,7 +83,7 @@ static int channels_to_mask( std::vector<size_t> channels ) {
 	return mask;
 }
 
-static void check_mtu( const std::string & remote_addr ) {
+static uint32_t get_if_mtu( const std::string & remote_addr ) {
 
 	std::string iface;
 
@@ -101,6 +102,8 @@ static void check_mtu( const std::string & remote_addr ) {
 			).str()
 		);
 	}
+
+	return mtu;
 }
 
 class crimson_tng_rx_streamer : public uhd::rx_streamer {
@@ -327,6 +330,7 @@ private:
 
 		// if no channels specified, default to channel 1 (0)
 		_channels = _channels.empty() ? std::vector<size_t>(1, 0) : _channels;
+		_if_mtu = std::vector<size_t>( _channels.size() );
 
 		_fifo = std::vector<std::queue<uint8_t>>( _channels.size() );
 
@@ -343,7 +347,7 @@ private:
 			_rate = tree->access<double>(mb_path / "rx_dsps" / "Channel_"+ch / "rate" / "value").get();
 			_pay_len = tree->access<int>(mb_path / "link" / iface / "pay_len").get();
 
-			check_mtu( ip_addr );
+			_if_mtu[ i ] = get_if_mtu( ip_addr );
 
 			// power on the channel
 			tree->access<std::string>(mb_path / "rx" / "Channel_"+ch / "pwr").set("1");
@@ -387,6 +391,7 @@ private:
 	property_tree::sptr _tree;
 	size_t _prev_frame;
 	size_t _pay_len;
+	std::vector<size_t> _if_mtu;
 	double _rate;
 	uint64_t _start_ticks;
 	device_addr_t _addr;
@@ -465,7 +470,6 @@ public:
 	}
 
 
-
 	size_t send(
         	const buffs_type &buffs,
         	const size_t nsamps_per_buff,
@@ -500,18 +504,23 @@ public:
 		}
 
 		compose_if_packet_info( metadata, if_packet_info );
-		if ( is_start_of_burst( if_packet_info ) ) {
-			_sob_time = metadata.time_spec.get_real_secs();
+		if ( metadata.has_time_spec ) {
 			for( unsigned i = 0; i < _channels.size(); i++ ) {
 				// start sending SoB data 1/2 a buffer (in time) before SoB
-				_last_time[ i ] = metadata.time_spec - (double)( CRIMSON_TNG_BUFF_SIZE / 2 ) / _crimson_samp_rate[ i ] ;
+				double half_buffer = CRIMSON_TNG_BUFF_SIZE / 2.0 / _crimson_samp_rate[ i ];
+				_last_time[ i ] = metadata.time_spec - uhd::time_spec_t( half_buffer );
+//				UHD_MSG( status ) << "SoB Info[ " << i << " ]:\n\t"
+//					<< "_last_time[ " << i << " ]: " << std::setprecision(10) << _last_time[ i ].get_real_secs() << "\n\t"
+//					<< "metadata.time_spec: " << std::setprecision(10) << metadata.time_spec.get_real_secs() << "\n\t"
+//					<< "_crimson_samp_rate[ " << i << " ]: " << _crimson_samp_rate[ i ] << "\n\t"
+//					<< "1/2 buffer[ " << i << " ]: " << std::setprecision(10) << half_buffer << std::endl;
 			}
 		}
 
 		// Timeout
 		time_spec_t timeout_lapsed = get_time_now() + time_spec_t(timeout) + ( metadata.has_time_spec ? metadata.time_spec : time_spec_t( 0.0 ) );
 
-		while ( samp_sent / 4 < nsamps_per_buff * _channels.size() ) {			// All Samples for all channels must be sent
+		while ( samp_sent < nsamps_per_buff * _channels.size() ) {			// All Samples for all channels must be sent
 			// send to each connected stream data in buffs[i]
 			for (unsigned int i = 0; i < _channels.size(); i++) {					// buffer to read in data plus room for VITA
 
@@ -520,33 +529,60 @@ public:
 					continue;
 				}
 
-				size_t ret = 0;
-				// update sample rate if we don't know the sample rate
-				setup_steadystate( i );
-
-				size_t samp_ptr_offset = nsamps_per_buff * 4 - remaining_bytes[ i ];
-				size_t data_len = std::min( CRIMSON_MAX_VITA_PAYLOAD_LEN_BYTES, remaining_bytes[ i ] ) & ~(4 - 1);
+				if ( ! metadata.has_time_spec ) {
+					// update sample rate if we don't know the sample rate
+					setup_steadystate( i );
+					update_samplerate( i );
+				}
 
 				if ( _en_fc ) {
 
+//					if ( _last_time[ i ] > get_time_now() ) {
+//						UHD_MSG( warning ) << "OVERFLOW: Channel " << (char)( 'A' + _channels[ i ] ) << std::endl;
+//					}
+//
 					if ( metadata.has_time_spec ) {
-						double dt = _last_time[ i ].get_real_secs() - get_time_now().get_real_secs();
-						if ( dt > 0.001 ) {
+
+						uhd::time_spec_t last = _last_time[ i ];
+						uhd::time_spec_t now = get_time_now();
+						uhd::time_spec_t dt = last - now;
+
+//						UHD_MSG( status ) << "SoB Sleep[ " << i << " ]:\n\t"
+//							<< "_last_time[ " << i << " ]: " << std::setprecision(10) << _last_time[ i ].get_real_secs() << "\n\t"
+//							<< "now: " << std::setprecision(10) << now.get_real_secs() << "\n\t";
+//
+						dt -= 10e-6;
+						if ( dt.get_real_secs() > 30e-6 ) {
 							//UHD_MSG( status ) << "sleeping " <<  (unsigned) ( ( dt - 0.001 ) * 1e6 ) << " us" << std::endl;
-							usleep( (unsigned) ( ( dt - 0.001 ) * 1e6 ) );
+							struct timespec req, rem;
+							req.tv_sec = (time_t) dt.get_full_secs();
+							req.tv_nsec = dt.get_frac_secs()*1e9;
+							nanosleep( &req, &rem );
+
+//							UHD_MSG( status )
+//								<< "SoB Sleep[ " << i << " ]:\n\t"
+//								<< "requested: " << ( ( req.tv_sec * 1000000000 + req.tv_nsec ) / 1e9 ) << "\n\t"
+//								<< "remaining: " << ( ( rem.tv_sec * 1000000000 + rem.tv_nsec ) / 1e9 )
+//								<< std::endl;
 						}
 					}
 					while ( ( get_time_now() < _last_time[i] ) ) {
-						update_samplerate( i );
+//						// nop
+						__asm__ __volatile__( "" );
 					}
 				}
 
-				if_packet_info.num_payload_words32 = data_len / 4;
+				size_t samp_ptr_offset = nsamps_per_buff * sizeof( uint32_t ) - remaining_bytes[ i ];
+
+				if_packet_info.num_header_words32 = metadata.has_time_spec ? 4 : 1;
+
+				size_t data_len = std::min( CRIMSON_MAX_VITA_PAYLOAD_LEN_BYTES, remaining_bytes[ i ] ) & ~(4 - 1);
+
+				if_packet_info.num_payload_words32 = data_len / sizeof( uint32_t );
 				if_packet_info.num_payload_bytes = data_len;
 
 				_tmp_buf[ i ][ 0 ] = 0;
 
-				if_packet_info.num_header_words32 = 1;
 				_tmp_buf[ i ][ 0 ] |= vrt::if_packet_info_t::PACKET_TYPE_DATA << 28;
 				_tmp_buf[ i ][ 0 ] |= 1 << 25; // set reserved bit (so wireshark works). this should eventually be removed
 
@@ -560,8 +596,6 @@ public:
 					_tmp_buf[ i ][ 1 ] = metadata.time_spec.get_full_secs();
 					_tmp_buf[ i ][ 2 ] = (uint32_t)( ps >> 32 );
 					_tmp_buf[ i ][ 3 ] = (uint32_t)( ps >> 0  );
-
-					if_packet_info.num_header_words32 += 3;
 				}
 
 				_tmp_buf[ i ][ 0 ] |= (uint16_t) ( if_packet_info.num_payload_words32 + if_packet_info.num_header_words32 );
@@ -575,7 +609,8 @@ public:
 
 //				UHD_MSG( status ) << "sending " << if_packet_info.num_payload_words32 << " samples to channel " << (char)( 'A' + _channels[ i ] ) << std::endl;
 
-				ret += _udp_stream[i] -> stream_out( _tmp_buf[ i ], header_len_bytes + data_len );
+				size_t ret = _udp_stream[i] -> stream_out( _tmp_buf[ i ], header_len_bytes + data_len );
+
 				//ret -= header_len_bytes;
 
 				//update last_time with when it was supposed to have been sent:
@@ -592,7 +627,7 @@ public:
 				}
 
 				remaining_bytes[i] -= data_len;
-				samp_sent += data_len;
+				samp_sent += data_len / sizeof( uint32_t );
 			}
 
 			// this ensures we only send the vita time spec on the first packet of the burst
@@ -600,11 +635,12 @@ public:
 
 			// Exit if Timeout has lapsed
 			if (get_time_now() > timeout_lapsed) {
-				return (samp_sent / 4) / _channels.size();
+				UHD_MSG( warning ) << __func__ << "():" << __LINE__ <<  ": timeout lapsed!!!" << std::endl;
+				return samp_sent / _channels.size();
 			}
 		}
 
-		return samp_sent / 4 / _channels.size();
+		return samp_sent / _channels.size();
 	}
 
 	// async messages are currently disabled
@@ -662,6 +698,7 @@ private:
 
 		// if no channels specified, default to channel 1 (0)
 		_channels = _channels.empty() ? std::vector<size_t>(1, 0) : _channels;
+		_if_mtu = std::vector<size_t>( _channels.size() );
 
 		if ( addr.has_key( "sync_multichannel_params" ) && "1" == addr[ "sync_multichannel_params" ] ) {
 			tree->access<int>( mb_path / "cm" / "chanmask-tx" ).set( channels_to_mask( _channels ) );
@@ -697,7 +734,7 @@ private:
 			std::string ip_addr  = tree->access<std::string>( mb_path / "link" / sfp / "ip_addr").get();
 			_pay_len = tree->access<int>(mb_path / "link" / sfp / "pay_len").get();
 
-			check_mtu( ip_addr );
+			_if_mtu[ i ] = get_if_mtu( ip_addr );
 
 			// power on the channel
 			tree->access<std::string>(mb_path / "tx" / "Channel_"+ch / "pwr").set("1");
@@ -744,7 +781,6 @@ private:
 			//Initialize "Time Diff" mechanism before starting flow control thread
 			time_spec_t ts = time_spec_t::get_system_time();
 			_streamer_start_time = ts.get_real_secs();
-			_sob_time = _streamer_start_time;
 			// The problem is that this class does not hold a multi_crimson instance
 			tree->access<time_spec_t>( time_path / "now" ).set( ts );
 
@@ -1004,10 +1040,10 @@ private:
 			if (samp_rate_update_ctr == 0) {
 				for (int c = 0; c < txstream->_channels.size(); c++) {
 					if (new_samp_rate[c] != txstream->_host_samp_rate[c]) {
-						if (new_samp_rate[c] < CRIMSON_TNG_SS_FIFOLVL_THRESHOLD)
+//						if (new_samp_rate[c] < CRIMSON_TNG_SS_FIFOLVL_THRESHOLD)
 							txstream->_fifo_level_perc[c] = 50;
-						else
-							txstream->_fifo_level_perc[c] = 80;
+//						else
+//							txstream->_fifo_level_perc[c] = 80;
 						txstream->_crimson_samp_rate[c] = new_samp_rate[c];
 						txstream->_host_samp_rate[c] = txstream->_crimson_samp_rate[c];
 					}
@@ -1049,6 +1085,7 @@ private:
 			txstream->_flowcontrol_mutex.unlock();
 		}
 
+		txstream->_flow_running = false;
 	}
 
 	// Actual Flow Control Controller
@@ -1114,10 +1151,10 @@ private:
 			_host_samp_rate[i] = _crimson_samp_rate[i];
 
 			// Set FIFO level steady state target accordingly
-			if (_crimson_samp_rate[i] < CRIMSON_TNG_SS_FIFOLVL_THRESHOLD)
+//			if (_crimson_samp_rate[i] < CRIMSON_TNG_SS_FIFOLVL_THRESHOLD)
 				_fifo_level_perc[i] = 50;
-			else
-				_fifo_level_perc[i] = 80;
+//			else
+//				_fifo_level_perc[i] = 80;
 		}
 
 		if (_crimson_samp_rate[i] == 0 || _underflow_flag[i]) {
@@ -1151,6 +1188,7 @@ private:
 	std::vector<time_spec_t> _last_time;
 	property_tree::sptr _tree;
 	size_t _pay_len;
+	std::vector<size_t> _if_mtu;
 	uhd::wb_iface::sptr _flow_iface;
 	boost::mutex _flowcontrol_mutex;
 	double _fifo_lvl[4];


### PR DESCRIPTION
1. Our MTU size was assuming only UDP header size of 8 bytes and ignoring
   IP header size
2. Fixed one case of segfaulting during ~crimson_tx_streamer()
3. Improved tx_from_file_crimson to not use threads
4. Only call setup_steady_state() and update_sample_rate() when we are
   not prepping for Start of Burst. This was a major problem because
   we had delayed half a buffer's worth of data in more than one spot in the
   code
5. Correctly computed VRT49 payload size based on MTU of network interface.