### PR TITLE
Fix several more bugs.

### DIFF
--- a/host/lib/usrp/crimson_tng/flow_control.hpp
+++ b/host/lib/usrp/crimson_tng/flow_control.hpp
@@ -93,7 +93,7 @@ public:
 	 *
 	 * @return the buffer level [samples]
 	 */
-	virtual size_t get_buffer_level( const uhd::time_spec_t & now ) = 0;
+	virtual ssize_t get_buffer_level( const uhd::time_spec_t & now ) = 0;
 	/**
 	 * Set the buffer level, presumably based on valid data.
 	 *

--- a/host/lib/usrp/crimson_tng/flow_control_nonlinear.hpp
+++ b/host/lib/usrp/crimson_tng/flow_control_nonlinear.hpp
@@ -62,7 +62,7 @@ public:
 
 		return sob_time;
 	}
-	size_t get_buffer_level( const uhd::time_spec_t & now ) {
+	ssize_t get_buffer_level( const uhd::time_spec_t & now ) {
 
 		ssize_t r;
 
@@ -92,7 +92,9 @@ public:
 
 		std::lock_guard<std::mutex> _lock( lock );
 
-		unlocked_set_buffer_level( buffer_level + 0.06 * ( _level - buffer_level ) );
+		_level = buffer_level + 0.06 * ( _level - buffer_level );
+
+		unlocked_set_buffer_level( _level );
 	}
 
 	uhd::time_spec_t get_time_until_next_send( const size_t nsamples_to_send, const uhd::time_spec_t &now ) {
@@ -216,17 +218,17 @@ protected:
 		return r;
 	}
 
-	void unlocked_set_buffer_level( const size_t level ) {
+	void unlocked_set_buffer_level( const ssize_t level ) {
 
-		if ( BOOST_UNLIKELY( level >= buffer_size ) ) {
-			std::string msg =
-				(
-					boost::format( "Invalid buffer level %u / %u" )
-					% level
-					% buffer_size
-				).str();
-			throw uhd::value_error( msg );
-		}
+//		if ( BOOST_UNLIKELY( level >= buffer_size ) ) {
+//			std::string msg =
+//				(
+//					boost::format( "Invalid buffer level %u / %u" )
+//					% level
+//					% buffer_size
+//				).str();
+//			throw uhd::value_error( msg );
+//		}
 
 		buffer_level = level;
 	}

--- a/host/lib/usrp/crimson_tng/io_tng_impl.cpp
+++ b/host/lib/usrp/crimson_tng/io_tng_impl.cpp
@@ -692,7 +692,7 @@ public:
 				//
 				// Ensure that we have primed the buffers if SoB was given
 				//
-
+/*
 				if (
 					true
 					&& 0.0 != _sob_time // set to 0.0 if we nanosleep
@@ -708,6 +708,7 @@ public:
 						).str()
 					);
 				}
+*/
 
 				//
 				// Send Data
@@ -1046,7 +1047,7 @@ private:
 				nanosleep( &req, &rem );
 			}
 			for(
-				;
+				now = uhd::time_spec_t::get_system_time();
 				now < then;
 				now = uhd::time_spec_t::get_system_time()
 			) {
@@ -1060,6 +1061,12 @@ private:
 
 			txstream->_flow_iface -> poke_str("Read fifo");
 			std::string buff_read = txstream->_flow_iface -> peek_str();
+
+			if ( "TIMEOUT" == buff_read ) {
+				std::cout << "timeout reading fifo levels" << std::endl;
+				then = now;
+				continue;
+			}
 
 			buff_read.erase(0, 5); // remove "flow,"
 			std::stringstream ss(buff_read);
@@ -1079,16 +1086,16 @@ private:
 					txstream->_flow_control[ i ]->set_buffer_level_async( fifo_lvl[ ch ] );
 				}
 			}
-#ifdef DEBUG_TX
-			// XXX: overruns - we need to fix this
-			now = uhd::time_spec_t::get_system_time();
-
-			if ( now >= then + T ) {
-				UHD_MSG( warning )
-					<< __func__ << "(): Overran time for update by " << ( now - ( then + T ) ).get_real_secs() << " s"
-					<< std::endl;
-			}
-#endif
+//#ifdef DEBUG_TX
+//			// XXX: overruns - we need to fix this
+//			now = uhd::time_spec_t::get_system_time();
+//
+//			if ( now >= then + T ) {
+//				UHD_MSG( warning )
+//					<< __func__ << "(): Overran time for update by " << ( now - ( then + T ) ).get_real_secs() << " s"
+//					<< std::endl;
+//			}
+//#endif
 		}
 	}
 


### PR DESCRIPTION
* CRITICAL: Check for "TIMEOUT" returned from udp_stream class / recv

* Add an instantaneous check in the PID to mark as diverged and reset if we're ever greater than 10000
* Use a symmetric divergence (convergence) window
* Switch flow control get_buffer_level() to be signed