### PR TITLE
Kb/4053/uhd asynchronous messages

### DIFF
--- a/host/lib/usrp/crimson_tng/crimson_tng_impl.cpp
+++ b/host/lib/usrp/crimson_tng/crimson_tng_impl.cpp
@@ -429,8 +429,8 @@ bool crimson_tng_impl::time_diff_recv( time_diff_resp & tdr ) {
 
 	for( int i = 0; i < CRIMSON_TNG_TX_CHANNELS; i++ ) {
 		boost::endian::big_to_native_inplace( tdr.fifo[ i ] );
-		boost::endian::big_to_native_inplace( tdr.uflow[ i ] );
-		boost::endian::big_to_native_inplace( tdr.oflow[ i ] );
+		boost::endian::big_to_native_inplace( tdr.uoflow[ i ].uflow );
+		boost::endian::big_to_native_inplace( tdr.uoflow[ i ].oflow );
 	}
 
 	return true;
@@ -589,17 +589,17 @@ void crimson_tng_impl::uoflow_update_counters( const time_diff_resp & tdr ) {
 
 		// update uflow counters, notify user on change
 
-		if ( _uoflow_report_en && _uflow[ j ] != tdr.uflow[ j ] ) {
+		if ( _uoflow_report_en && _uflow[ j ] != tdr.uoflow[ j ].uflow ) {
 			UHD_MSG( fastpath ) << "U" << ((char) ( 'a' + j ) );
 		}
-		_uflow[ j ] = tdr.uflow[ j ];
+		_uflow[ j ] = tdr.uoflow[ j ].uflow;
 
 		// update oflow counters, notify user on change
 
-		if ( _uoflow_report_en && _oflow[ j ] != tdr.oflow[ j ] ) {
+		if ( _uoflow_report_en && _oflow[ j ] != tdr.uoflow[ j ].oflow ) {
 			UHD_MSG( fastpath ) << "O" << ((char) ( 'a' + j ) );
 		}
-		_oflow[ j ] = tdr.oflow[ j ];
+		_oflow[ j ] = tdr.uoflow[ j ].oflow;
 
 	}
 }

--- a/host/lib/usrp/crimson_tng/crimson_tng_impl.cpp
+++ b/host/lib/usrp/crimson_tng/crimson_tng_impl.cpp
@@ -1030,7 +1030,6 @@ crimson_tng_impl::crimson_tng_impl(const device_addr_t &dev_addr)
 	_time_diff_pidc.set_error_filter_length( CRIMSON_TNG_UPDATE_PER_SEC );
 
 	start_bm();
-	stop_bm();
 }
 
 crimson_tng_impl::~crimson_tng_impl(void)

--- a/host/lib/usrp/crimson_tng/crimson_tng_impl.cpp
+++ b/host/lib/usrp/crimson_tng/crimson_tng_impl.cpp
@@ -36,7 +36,6 @@
 #include "uhd/transport/udp_simple.hpp"
 #include "uhd/utils/msg.hpp"
 #include "uhd/utils/static.hpp"
-#include "uhd/utils/thread_priority.hpp"
 
 #include "crimson_tng_rx_streamer.hpp"
 #include "crimson_tng_tx_streamer.hpp"
@@ -605,8 +604,6 @@ void crimson_tng_impl::uoflow_enable_reporting( bool en ) {
 void crimson_tng_impl::bm_thread_fn( crimson_tng_impl *dev ) {
 
 	dev->_bm_thread_running = true;
-
-	uhd::set_thread_priority_safe();
 
 	const uhd::time_spec_t T( 1.0 / (double) CRIMSON_TNG_UPDATE_PER_SEC );
 	std::vector<size_t> fifo_lvl( CRIMSON_TNG_TX_CHANNELS );

--- a/host/lib/usrp/crimson_tng/crimson_tng_impl.cpp
+++ b/host/lib/usrp/crimson_tng/crimson_tng_impl.cpp
@@ -1043,9 +1043,5 @@ crimson_tng_impl::~crimson_tng_impl(void)
 bool crimson_tng_impl::recv_async_msg( uhd::async_metadata_t &async_metadata, double timeout ) {
 	boost::ignore_unused( async_metadata );
 	boost::ignore_unused( timeout );
-
-	UHD_MSG( status ) << __func__ << "() called" << std::endl;
-	// would I typically call standard_async_msg_prints() here??
-
 	return false;
 }

--- a/host/lib/usrp/crimson_tng/crimson_tng_impl.cpp
+++ b/host/lib/usrp/crimson_tng/crimson_tng_impl.cpp
@@ -1000,14 +1000,6 @@ crimson_tng_impl::crimson_tng_impl(const device_addr_t &dev_addr)
 		_oflow[ j ] = _tree->access<int>( "/mboards/0/tx" / std::to_string( (char)( 'a' + j ) ) / "qa/oflow" ).set( 0 ).get();
 	}
 
-	// setup the flow control UDP channel
-	_bm_iface = crimson_tng_iface::make(
-		udp_simple::make_connected(
-			_addr["addr"],
-			BOOST_STRINGIZE(CRIMSON_TNG_FLOW_CNTRL_UDP_PORT)
-		)
-	);
-
 	// it does not currently matter whether we use the sfpa or sfpb port atm, they both access the same fpga hardware block
 	int sfpa_port = _tree->access<int>( mb_path / "fpga/board/flow_control/sfpa_port" ).get();
 	std::string time_diff_ip = _tree->access<std::string>( mb_path / "link" / "sfpa" / "ip_addr" ).get();

--- a/host/lib/usrp/crimson_tng/crimson_tng_impl.hpp
+++ b/host/lib/usrp/crimson_tng/crimson_tng_impl.hpp
@@ -153,7 +153,7 @@ private:
 	bool _time_diff_converged;
 	uhd::time_spec_t _streamer_start_time;
     void time_diff_send( const uhd::time_spec_t & crimson_now );
-    void time_diff_recv( time_diff_resp & tdr );
+    bool time_diff_recv( time_diff_resp & tdr );
     void time_diff_process( const time_diff_resp & tdr, const uhd::time_spec_t & now );
     void fifo_update_process( const time_diff_resp & tdr );
 

--- a/host/lib/usrp/crimson_tng/crimson_tng_impl.hpp
+++ b/host/lib/usrp/crimson_tng/crimson_tng_impl.hpp
@@ -45,8 +45,8 @@ struct time_diff_req {
 
 #pragma pack(push,1)
 struct time_diff_uoflow {
-	uint32_t uflow;
-	uint32_t oflow;
+	uint64_t uflow;
+	uint64_t oflow;
 };
 #pragma pack(pop)
 
@@ -177,8 +177,8 @@ private:
 	bool _bm_thread_should_exit;
 	static void bm_thread_fn( crimson_tng_impl *dev );
 
-	std::vector<uint32_t> _uflow;
-	std::vector<uint32_t> _oflow;
+	std::vector<uint64_t> _uflow;
+	std::vector<uint64_t> _oflow;
 	bool _uoflow_report_en;
 };
 

--- a/host/lib/usrp/crimson_tng/crimson_tng_impl.hpp
+++ b/host/lib/usrp/crimson_tng/crimson_tng_impl.hpp
@@ -44,12 +44,18 @@ struct time_diff_req {
 #pragma pack(pop)
 
 #pragma pack(push,1)
+struct time_diff_uoflow {
+	uint32_t uflow;
+	uint32_t oflow;
+};
+#pragma pack(pop)
+
+#pragma pack(push,1)
 struct time_diff_resp {
 	int64_t tv_sec;
 	int64_t tv_tick;
 	uint16_t fifo[ CRIMSON_TNG_TX_CHANNELS ];
-	uint32_t uflow[ CRIMSON_TNG_TX_CHANNELS ];
-	uint32_t oflow[ CRIMSON_TNG_TX_CHANNELS ];
+	struct time_diff_uoflow uoflow[ CRIMSON_TNG_TX_CHANNELS ];
 };
 #pragma pack(pop)
 

--- a/host/lib/usrp/crimson_tng/crimson_tng_impl.hpp
+++ b/host/lib/usrp/crimson_tng/crimson_tng_impl.hpp
@@ -163,8 +163,8 @@ private:
 
     std::set<uhd::crimson_tng_tx_streamer *> _bm_listeners;
 
-	crimson_tng_iface::sptr _bm_iface;
 	// N.B: the _bm_thread is also used for clock domain synchronization
+	// N.B: the _bm_iface was removed in favour of using the _time_diff_iface
 	std::thread _bm_thread;
 	std::mutex _bm_thread_mutex;
 	bool _bm_thread_running;

--- a/host/lib/usrp/crimson_tng/crimson_tng_tx_streamer.cpp
+++ b/host/lib/usrp/crimson_tng/crimson_tng_tx_streamer.cpp
@@ -180,7 +180,6 @@ size_t crimson_tng_tx_streamer::send(
 	uhd::time_spec_t send_deadline;
 
 	uhd::usrp::crimson_tng_impl *dev = static_cast<uhd::usrp::crimson_tng_impl *>( _dev );
-	dev->start_bm();
 	dev->uoflow_enable_reporting();
 
 	if (

--- a/host/lib/usrp/crimson_tng/crimson_tng_tx_streamer.cpp
+++ b/host/lib/usrp/crimson_tng/crimson_tng_tx_streamer.cpp
@@ -181,6 +181,7 @@ size_t crimson_tng_tx_streamer::send(
 
 	uhd::usrp::crimson_tng_impl *dev = static_cast<uhd::usrp::crimson_tng_impl *>( _dev );
 	dev->start_bm();
+	dev->uoflow_enable_reporting();
 
 	if (
 		true


### PR DESCRIPTION
Switch to in-band feedback for time diff packet fifo levels under and… …… overflow counters

* switch to in-band feedback for time diff response
  * time diff response does not have a header, we should probably fix that
  * brings up topic of IDL / RPC services again.. (ahem Thrift)
  * I think it would make sense to offload processing of in-band packets to the ARM
* in-band feedback (time diff response) now contains
  * time diff (not qualified by a cookie yet)
  * fifo levels
  * underrun counter
  * overrun counter
* Do not stop and restart bm
  * Since time diff and buffer management is now handled in-band, we shouldn't need to temporarily pause it during startup, as there will be no contention (in terms of server processing time) for management
commands.
* Run bm_thread_fn at non-real-time priority

