### PR TITLE
Kb/4063/uhd fix time diff divergence issues

### DIFF
--- a/host/lib/usrp/crimson_tng/crimson_tng_fw_common.h
+++ b/host/lib/usrp/crimson_tng/crimson_tng_fw_common.h
@@ -69,7 +69,7 @@ extern "C" {
 #define CRIMSON_TNG_MAX_MTU		9000
 
 // Crimson Flowcontrol Update Per Second
-#define CRIMSON_TNG_UPDATE_PER_SEC	50
+#define CRIMSON_TNG_UPDATE_PER_SEC	100
 #define CRIMSON_TNG_SS_FIFOLVL_THRESHOLD 107421875
 
 // Crimson Buffer Size

--- a/host/lib/usrp/crimson_tng/pidc.hpp
+++ b/host/lib/usrp/crimson_tng/pidc.hpp
@@ -137,6 +137,9 @@ namespace uhd {
 			filtered_error = error_filter.get_average();
 
 			if ( filtered_error >= 10000 ) {
+				print_pid_diverged();
+				print_pid_status( time, cv, filtered_error );
+				reset( sp, time );
 				return false;
 			}
 
@@ -156,6 +159,8 @@ namespace uhd {
 					converged = false;
 					print_pid_diverged();
 					print_pid_status( time, cv, filtered_error );
+					reset( sp, time );
+					print_pid_reset();
 				}
 			}
 

--- a/host/lib/usrp/crimson_tng/pidc.hpp
+++ b/host/lib/usrp/crimson_tng/pidc.hpp
@@ -20,7 +20,7 @@ namespace uhd {
 
 	public:
 
-		static constexpr double DEFAULT_MAX_ERROR_FOR_DIVERGENCE = 100e-6;
+		static constexpr double DEFAULT_MAX_ERROR_FOR_DIVERGENCE = 10e-6;
 
 		typedef enum {
 			K_P,
@@ -156,6 +156,7 @@ namespace uhd {
 				}
 			} else {
 				if ( filtered_error >= max_error_for_divergence ) {
+					converged = false;
 					print_pid_diverged();
 					print_pid_status( time, cv, filtered_error );
 					reset( sp, time );

--- a/host/lib/usrp/crimson_tng/pidc.hpp
+++ b/host/lib/usrp/crimson_tng/pidc.hpp
@@ -137,9 +137,6 @@ namespace uhd {
 			filtered_error = error_filter.get_average();
 
 			if ( filtered_error >= 10000 ) {
-				print_pid_diverged();
-				print_pid_status( time, cv, filtered_error );
-				reset( sp, time );
 				return false;
 			}
 
@@ -159,8 +156,6 @@ namespace uhd {
 					converged = false;
 					print_pid_diverged();
 					print_pid_status( time, cv, filtered_error );
-					reset( sp, time );
-					print_pid_reset();
 				}
 			}
 

--- a/host/lib/usrp/crimson_tng/pidc.hpp
+++ b/host/lib/usrp/crimson_tng/pidc.hpp
@@ -149,7 +149,7 @@ namespace uhd {
 			}
 
 			if ( ! converged ) {
-				if ( filtered_error < max_error_for_divergence ) {
+				if ( filtered_error < max_error_for_divergence * 0.9 ) {
 					converged = true;
 					print_pid_status( time, cv, filtered_error );
 					print_pid_converged();

--- a/host/lib/usrp/crimson_tng/pidc.hpp
+++ b/host/lib/usrp/crimson_tng/pidc.hpp
@@ -137,8 +137,10 @@ namespace uhd {
 			filtered_error = error_filter.get_average();
 
 			if ( filtered_error >= 10000 ) {
-				print_pid_diverged();
-				print_pid_status( time, cv, filtered_error );
+				if ( time - last_status_time >= 1 ) {
+					print_pid_diverged();
+					print_pid_status( time, cv, filtered_error );
+				}
 				reset( sp, time );
 				return false;
 			}
@@ -159,8 +161,6 @@ namespace uhd {
 					converged = false;
 					print_pid_diverged();
 					print_pid_status( time, cv, filtered_error );
-					reset( sp, time );
-					print_pid_reset();
 				}
 			}
 


### PR DESCRIPTION

* Assuming a small enough divergence window, the PID time-convergence diverging should **not** affect flow control. In other words, once the PID has converged, we should **always** have an accurate estimate of the time diff. However, the assumption was that the divergence window was small enough.  If the sample rate is high, even a 100us divergence window will overflow or underflow the buffer.  Shrink the divergence window to 10us.  Also, for some reason, 'converged' was never set to false in pidc::is_converged(). Fixed that.
* To avoid 'bouncing', we have 10% hysteresis for convergence.
* The zero-forcing PID controller should not need to be reset.
* Increase buffer-management sample rate to 100 Hz