### PR TITLE
Kb/4064/uhd usrp probe and usrp find devices should not perform clock domain convergence

### DIFF
--- a/host/lib/usrp/crimson_tng/crimson_tng_fw_common.h
+++ b/host/lib/usrp/crimson_tng/crimson_tng_fw_common.h
@@ -69,7 +69,7 @@ extern "C" {
 #define CRIMSON_TNG_MAX_MTU		9000
 
 // Crimson Flowcontrol Update Per Second
-#define CRIMSON_TNG_UPDATE_PER_SEC	50
+#define CRIMSON_TNG_UPDATE_PER_SEC	100
 #define CRIMSON_TNG_SS_FIFOLVL_THRESHOLD 107421875
 
 // Crimson Buffer Size

--- a/host/lib/usrp/crimson_tng/crimson_tng_impl.hpp
+++ b/host/lib/usrp/crimson_tng/crimson_tng_impl.hpp
@@ -173,9 +173,11 @@ private:
 	// N.B: the _bm_iface was removed in favour of using the _time_diff_iface
 	std::thread _bm_thread;
 	std::mutex _bm_thread_mutex;
+	bool _bm_thread_needed;
 	bool _bm_thread_running;
 	bool _bm_thread_should_exit;
 	static void bm_thread_fn( crimson_tng_impl *dev );
+	bool is_bm_thread_needed();
 
 	std::vector<uint64_t> _uflow;
 	std::vector<uint64_t> _oflow;

--- a/host/lib/usrp/crimson_tng/pidc.hpp
+++ b/host/lib/usrp/crimson_tng/pidc.hpp
@@ -137,6 +137,9 @@ namespace uhd {
 			filtered_error = error_filter.get_average();
 
 			if ( filtered_error >= 10000 ) {
+				print_pid_diverged();
+				print_pid_status( time, cv, filtered_error );
+				reset( sp, time );
 				return false;
 			}
 
@@ -156,6 +159,8 @@ namespace uhd {
 					converged = false;
 					print_pid_diverged();
 					print_pid_status( time, cv, filtered_error );
+					reset( sp, time );
+					print_pid_reset();
 				}
 			}
 

--- a/host/lib/usrp/crimson_tng/pidc.hpp
+++ b/host/lib/usrp/crimson_tng/pidc.hpp
@@ -20,7 +20,7 @@ namespace uhd {
 
 	public:
 
-		static constexpr double DEFAULT_MAX_ERROR_FOR_DIVERGENCE = 100e-6;
+		static constexpr double DEFAULT_MAX_ERROR_FOR_DIVERGENCE = 10e-6;
 
 		typedef enum {
 			K_P,
@@ -156,6 +156,7 @@ namespace uhd {
 				}
 			} else {
 				if ( filtered_error >= max_error_for_divergence ) {
+					converged = false;
 					print_pid_diverged();
 					print_pid_status( time, cv, filtered_error );
 					reset( sp, time );

--- a/host/lib/usrp/crimson_tng/pidc.hpp
+++ b/host/lib/usrp/crimson_tng/pidc.hpp
@@ -137,9 +137,6 @@ namespace uhd {
 			filtered_error = error_filter.get_average();
 
 			if ( filtered_error >= 10000 ) {
-				print_pid_diverged();
-				print_pid_status( time, cv, filtered_error );
-				reset( sp, time );
 				return false;
 			}
 
@@ -159,8 +156,6 @@ namespace uhd {
 					converged = false;
 					print_pid_diverged();
 					print_pid_status( time, cv, filtered_error );
-					reset( sp, time );
-					print_pid_reset();
 				}
 			}
 

--- a/host/lib/usrp/crimson_tng/pidc.hpp
+++ b/host/lib/usrp/crimson_tng/pidc.hpp
@@ -149,7 +149,7 @@ namespace uhd {
 			}
 
 			if ( ! converged ) {
-				if ( filtered_error < max_error_for_divergence ) {
+				if ( filtered_error < max_error_for_divergence * 0.9 ) {
 					converged = true;
 					print_pid_status( time, cv, filtered_error );
 					print_pid_converged();

--- a/host/lib/usrp/crimson_tng/pidc.hpp
+++ b/host/lib/usrp/crimson_tng/pidc.hpp
@@ -137,8 +137,10 @@ namespace uhd {
 			filtered_error = error_filter.get_average();
 
 			if ( filtered_error >= 10000 ) {
-				print_pid_diverged();
-				print_pid_status( time, cv, filtered_error );
+				if ( time - last_status_time >= 1 ) {
+					print_pid_diverged();
+					print_pid_status( time, cv, filtered_error );
+				}
 				reset( sp, time );
 				return false;
 			}
@@ -159,8 +161,6 @@ namespace uhd {
 					converged = false;
 					print_pid_diverged();
 					print_pid_status( time, cv, filtered_error );
-					reset( sp, time );
-					print_pid_reset();
 				}
 			}
 


### PR DESCRIPTION
Please pull #73 before this!

Certain programs, such as uhd_find_devices and uhd_usrp_probe, do not need libuhd to perform time_domain convergence.

A quick & easy solution is to compare the basename( argv[ 0 ] ) (i.e. the program_invocation_short_name) to a blacklist.

See `man 3 program_invocation_short_name' for more details.