### PR TITLE
Coarse to Fine Clock Domain Synchronization

### DIFF
--- a/host/lib/usrp/crimson_tng/crimson_tng_impl.cpp
+++ b/host/lib/usrp/crimson_tng/crimson_tng_impl.cpp
@@ -1040,9 +1040,15 @@ crimson_tng_impl::crimson_tng_impl(const device_addr_t &dev_addr)
 			// measured P-ultimate is inverse of 1/2 the flow-control sample rate
 			2.0 / (double)CRIMSON_TNG_UPDATE_PER_SEC
 		);
+
 		_time_diff_pidc.set_error_filter_length( CRIMSON_TNG_UPDATE_PER_SEC );
 
+		// XXX: @CF: 20170720: coarse to fine for convergence
+		// we coarsely lock on at first, to ensure the class instantiates properly
+		// and then switch to a finer error tolerance
+		_time_diff_pidc.set_max_error_for_convergence( 100e-6 );
 		start_bm();
+		_time_diff_pidc.set_max_error_for_convergence( 10e-6 );
 	}
 }
 


### PR DESCRIPTION
After switching from an RT kernel to a non-RT kernel, we encountered difficulty synchronizing initially to 10ppm.

When instantiating a crimson_tng_impl, rather than timeout and throw an exception because we have not synchronized to 10ppm, only synchronize to 100ppm. Then once that is done, decrease the tolerance to 10ppm.

We still throw an exception if we are unable to converge to 100ppm, initially.