### PR TITLE
Kb/4045/uhd multiple streamer threads performs poorly

### DIFF
--- a/host/examples/tx_waveforms_crimson.cpp
+++ b/host/examples/tx_waveforms_crimson.cpp
@@ -92,11 +92,11 @@ int UHD_SAFE_MAIN(int argc, char *argv[]){
         ("spb", po::value<size_t>(&spb)->default_value(0), "samples per buffer, 0 for default")
 		("sob", po::value<double>(&sob)->default_value(0.5), "start of burst in N seconds, 0 to disable")
         ("rate", po::value<double>(&rate)->default_value(10e6), "rate of outgoing samples")
-        ("freq", po::value<double>(&freq)->default_value(2.4e9), "RF center frequency in Hz")
-        ("ampl", po::value<float>(&ampl)->default_value(float(1500)), "amplitude of the waveform [0 to 32767]")
+        ("freq", po::value<double>(&freq)->default_value(15e6), "RF center frequency in Hz")
+        ("ampl", po::value<float>(&ampl)->default_value(float(15000)), "amplitude of the waveform [0 to 32767]")
         ("gain", po::value<double>(&gain)->default_value(20), "gain for the RF chain")
-        ("wave-type", po::value<std::string>(&wave_type)->default_value("SINE"), "waveform type (CONST, SQUARE, RAMP, SINE)")
-        ("wave-freq", po::value<double>(&wave_freq)->default_value( 5e6 ), "waveform frequency in Hz")
+        ("wave-type", po::value<std::string>(&wave_type)->default_value("CONST"), "waveform type (CONST, SQUARE, RAMP, SINE)")
+        ("wave-freq", po::value<double>(&wave_freq)->default_value( 300e3 ), "waveform frequency in Hz")
         ("ref", po::value<std::string>(&ref)->default_value("internal"), "clock reference (internal, external, mimo)")
         ("channels", po::value<std::string>(&channel_list)->default_value("0,1,2,3"), "which channels to use (specify \"0\", \"1\", \"0,1\", etc)")
     ;
@@ -131,7 +131,7 @@ int UHD_SAFE_MAIN(int argc, char *argv[]){
     //Lock mboard clocks
     usrp->set_clock_source(ref);
 
-    std::cout << boost::format("Using Device: %s") % usrp->get_pp_string() << std::endl;
+    //std::cout << boost::format("Using Device: %s") % usrp->get_pp_string() << std::endl;
 
     //set the sample rate
     if (not vm.count("rate")){

--- a/host/lib/usrp/crimson_tng/crimson_tng_impl.cpp
+++ b/host/lib/usrp/crimson_tng/crimson_tng_impl.cpp
@@ -457,7 +457,7 @@ void crimson_tng_impl::fifo_update_process( const time_diff_resp & tdr ) {
 	// for now we have to copy the fifo levels into a std::vector<size_t> for processing
 	std::vector<size_t> fifo_lvl( CRIMSON_TNG_TX_CHANNELS, 0 );
 	for( int j = 0; j < CRIMSON_TNG_TX_CHANNELS; j++ ) {
-		fifo_lvl[ j ] = tdr.fifo[ j ];
+		fifo_lvl[ j ] = tdr.fifo[ CRIMSON_TNG_TX_CHANNELS - j - 1 ];
 	}
 
 	if ( _time_diff_converged ) {

--- a/host/lib/usrp/crimson_tng/crimson_tng_impl.cpp
+++ b/host/lib/usrp/crimson_tng/crimson_tng_impl.cpp
@@ -640,7 +640,7 @@ void crimson_tng_impl::bm_thread_fn( crimson_tng_impl *dev ) {
 	) {
 
 		dt = then - now;
-		if ( dt > 100e-6 ) {
+		if ( dt > 1e-3 ) {
 			dt -= 30e-6;
 			req.tv_sec = dt.get_full_secs();
 			req.tv_nsec = dt.get_frac_secs() * 1e9;

--- a/host/lib/usrp/crimson_tng/crimson_tng_impl.cpp
+++ b/host/lib/usrp/crimson_tng/crimson_tng_impl.cpp
@@ -1040,9 +1040,15 @@ crimson_tng_impl::crimson_tng_impl(const device_addr_t &dev_addr)
 			// measured P-ultimate is inverse of 1/2 the flow-control sample rate
 			2.0 / (double)CRIMSON_TNG_UPDATE_PER_SEC
 		);
+
 		_time_diff_pidc.set_error_filter_length( CRIMSON_TNG_UPDATE_PER_SEC );
 
+		// XXX: @CF: 20170720: coarse to fine for convergence
+		// we coarsely lock on at first, to ensure the class instantiates properly
+		// and then switch to a finer error tolerance
+		_time_diff_pidc.set_max_error_for_convergence( 100e-6 );
 		start_bm();
+		_time_diff_pidc.set_max_error_for_convergence( 10e-6 );
 	}
 }
 

--- a/host/lib/usrp/crimson_tng/crimson_tng_tx_streamer.cpp
+++ b/host/lib/usrp/crimson_tng/crimson_tng_tx_streamer.cpp
@@ -261,7 +261,7 @@ size_t crimson_tng_tx_streamer::send(
 				);
 			then = now + dt;
 			// XXX: @CF: 20170717: Instead of hard-coding values here, calibrate the delay loop on init using a method similar to rt_tests/cyclictest
-			if ( dt.get_real_secs() > 1e-3 ) {
+			if ( dt.get_real_secs() > 100e-6 ) {
 				dt -= 30e-6;
 				struct timespec req, rem;
 				req.tv_sec = (time_t) dt.get_full_secs();

--- a/host/lib/usrp/crimson_tng/crimson_tng_tx_streamer.cpp
+++ b/host/lib/usrp/crimson_tng/crimson_tng_tx_streamer.cpp
@@ -260,6 +260,7 @@ size_t crimson_tng_tx_streamer::send(
 					now
 				);
 			then = now + dt;
+			// XXX: @CF: 20170717: Instead of hard-coding values here, calibrate the delay loop on init using a method similar to rt_tests/cyclictest
 			if ( dt.get_real_secs() > 1e-3 ) {
 				dt -= 30e-6;
 				struct timespec req, rem;

--- a/host/lib/usrp/crimson_tng/crimson_tng_tx_streamer.cpp
+++ b/host/lib/usrp/crimson_tng/crimson_tng_tx_streamer.cpp
@@ -261,7 +261,7 @@ size_t crimson_tng_tx_streamer::send(
 				);
 			then = now + dt;
 			// XXX: @CF: 20170717: Instead of hard-coding values here, calibrate the delay loop on init using a method similar to rt_tests/cyclictest
-			if ( dt.get_real_secs() > 100e-6 ) {
+			if ( dt.get_real_secs() > 1e-3 ) {
 				dt -= 30e-6;
 				struct timespec req, rem;
 				req.tv_sec = (time_t) dt.get_full_secs();


### PR DESCRIPTION
The main part of this pull request is in:

host/lib/usrp/crimson_tng/crimson_tng_impl.cpp

The remainder was
* add thread affinity, so thread 0 is stuck with core 0, thread 1, with core 1, etc.
* fix default arguments for tx_waveforms_crimson to be more conventional