### PR TITLE
Kb/4070/uhd ensure only one buffer management thread is running per process

### DIFF
--- a/host/lib/usrp/crimson_tng/crimson_tng_impl.cpp
+++ b/host/lib/usrp/crimson_tng/crimson_tng_impl.cpp
@@ -727,6 +727,8 @@ std::vector<size_t> crimson_tng_impl::_oflow( CRIMSON_TNG_TX_CHANNELS, 0 );
 std::vector<size_t> crimson_tng_impl::_uflow( CRIMSON_TNG_TX_CHANNELS, 0 );
 bool crimson_tng_impl::_uoflow_report_en;
 
+std::set<uhd::crimson_tng_tx_streamer *> crimson_tng_impl::_bm_listeners;
+
 bool crimson_tng_impl::_time_diff_converged;
 double crimson_tng_impl::_time_diff;
 

--- a/host/lib/usrp/crimson_tng/crimson_tng_impl.cpp
+++ b/host/lib/usrp/crimson_tng/crimson_tng_impl.cpp
@@ -627,6 +627,8 @@ void crimson_tng_impl::bm_thread_fn( crimson_tng_impl *dev ) {
 
 	struct time_diff_resp tdr;
 
+	std::cout << __func__ << "(): This is thread " << _bm_thread.get_id() << std::endl;
+
 	for(
 		now = uhd::time_spec_t::get_system_time(),
 			then = now + T
@@ -718,6 +720,7 @@ UHD_STATIC_BLOCK(register_crimson_tng_device)
 // Macro to create the tree, all properties created with this are static
 #define TREE_CREATE_ST(PATH, TYPE, VAL) 	( _tree->create<TYPE>(PATH).set(VAL) )
 
+std::thread crimson_tng_impl::_bm_thread;
 std::mutex crimson_tng_impl::_bm_thread_mutex;
 bool crimson_tng_impl::_bm_thread_needed;
 bool crimson_tng_impl::_bm_thread_running;

--- a/host/lib/usrp/crimson_tng/crimson_tng_impl.cpp
+++ b/host/lib/usrp/crimson_tng/crimson_tng_impl.cpp
@@ -15,14 +15,6 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //
 
-#ifndef DEBUG_BM
-#define DEBUG_BM 1
-#endif
-
-#ifdef DEBUG_BM
-#include <iostream>
-#endif
-
 #include <boost/assign.hpp>
 #include <boost/asio.hpp>
 #include <boost/bind.hpp>
@@ -39,6 +31,10 @@
 
 #include "crimson_tng_rx_streamer.hpp"
 #include "crimson_tng_tx_streamer.hpp"
+
+#ifdef DEBUG_BM
+#include <iostream>
+#endif
 
 using namespace uhd;
 using namespace uhd::usrp;
@@ -439,6 +435,9 @@ bool crimson_tng_impl::time_diff_recv( time_diff_resp & tdr ) {
 /// SoB Time Diff: feed the time diff error back into out control system
 void crimson_tng_impl::time_diff_process( const time_diff_resp & tdr, const uhd::time_spec_t & now ) {
 
+	static uhd::time_spec_t then;
+	uhd::time_spec_t right_now;
+
 	static const double sp = 0.0;
 
 	double pv = (double) tdr.tv_sec + (double)ticks_to_nsecs( tdr.tv_tick ) / 1e9;
@@ -448,6 +447,13 @@ void crimson_tng_impl::time_diff_process( const time_diff_resp & tdr, const uhd:
 
 	// For SoB, record the instantaneous time difference + compensation
 	if ( _time_diff_converged ) {
+#ifdef DEBUG_BM
+		right_now = uhd::time_spec_t::get_system_time();
+		if ( right_now - then > 1.0 ) {
+			then = right_now;
+			std::cout << std::endl << __func__ << "(): Time Diff: " << cv << std::endl;
+		}
+#endif
 		time_diff_set( cv );
 	}
 }
@@ -597,22 +603,38 @@ void crimson_tng_impl::bm_listener_rem( uhd::crimson_tng_tx_streamer *listener )
 }
 
 void crimson_tng_impl::uoflow_update_counters( const time_diff_resp & tdr ) {
+
+	std::stringstream uflow_ss;
+	std::stringstream oflow_ss;
+
+	std::string uflow_s;
+	std::string oflow_s;
+
 	for ( int j = 0; j < CRIMSON_TNG_TX_CHANNELS; j++ ) {
 
 		// update uflow counters, notify user on change
 
 		if ( _uoflow_report_en && _uflow[ j ] != tdr.uoflow[ j ].uflow ) {
-			UHD_MSG( fastpath ) << "U" << ((char) ( 'a' + j ) );
+			uflow_ss << "U" << ((char) ( 'a' + j ) );
 		}
 		_uflow[ j ] = tdr.uoflow[ j ].uflow;
 
 		// update oflow counters, notify user on change
 
 		if ( _uoflow_report_en && _oflow[ j ] != tdr.uoflow[ j ].oflow ) {
-			UHD_MSG( fastpath ) << "O" << ((char) ( 'a' + j ) );
+			oflow_ss << "O" << ((char) ( 'a' + j ) );
 		}
 		_oflow[ j ] = tdr.uoflow[ j ].oflow;
 
+	}
+
+	uflow_s = uflow_ss.str();
+	if ( ! uflow_s.empty() ) {
+		UHD_MSG( fastpath ) << uflow_s;
+	}
+	oflow_s = oflow_ss.str();
+	if ( ! oflow_s.empty() ) {
+		UHD_MSG( fastpath ) << oflow_s;
 	}
 }
 

--- a/host/lib/usrp/crimson_tng/crimson_tng_impl.cpp
+++ b/host/lib/usrp/crimson_tng/crimson_tng_impl.cpp
@@ -640,7 +640,7 @@ void crimson_tng_impl::bm_thread_fn( crimson_tng_impl *dev ) {
 	) {
 
 		dt = then - now;
-		if ( dt > 1e-3 ) {
+		if ( dt > 100e-6 ) {
 			dt -= 30e-6;
 			req.tv_sec = dt.get_full_secs();
 			req.tv_nsec = dt.get_frac_secs() * 1e9;

--- a/host/lib/usrp/crimson_tng/crimson_tng_impl.cpp
+++ b/host/lib/usrp/crimson_tng/crimson_tng_impl.cpp
@@ -640,7 +640,7 @@ void crimson_tng_impl::bm_thread_fn( crimson_tng_impl *dev ) {
 	) {
 
 		dt = then - now;
-		if ( dt > 100e-6 ) {
+		if ( dt > 1e-3 ) {
 			dt -= 30e-6;
 			req.tv_sec = dt.get_full_secs();
 			req.tv_nsec = dt.get_frac_secs() * 1e9;

--- a/host/lib/usrp/crimson_tng/crimson_tng_impl.cpp
+++ b/host/lib/usrp/crimson_tng/crimson_tng_impl.cpp
@@ -718,16 +718,19 @@ UHD_STATIC_BLOCK(register_crimson_tng_device)
 // Macro to create the tree, all properties created with this are static
 #define TREE_CREATE_ST(PATH, TYPE, VAL) 	( _tree->create<TYPE>(PATH).set(VAL) )
 
+std::mutex crimson_tng_impl::_bm_thread_mutex;
+bool crimson_tng_impl::_bm_thread_needed;
+bool crimson_tng_impl::_bm_thread_running;
+bool crimson_tng_impl::_bm_thread_should_exit;
+
+std::vector<size_t> crimson_tng_impl::_oflow( CRIMSON_TNG_TX_CHANNELS, 0 );
+std::vector<size_t> crimson_tng_impl::_uflow( CRIMSON_TNG_TX_CHANNELS, 0 );
+bool crimson_tng_impl::_uoflow_report_en;
+
+bool crimson_tng_impl::_time_diff_converged;
+double crimson_tng_impl::_time_diff;
+
 crimson_tng_impl::crimson_tng_impl(const device_addr_t &dev_addr)
-:
-	_bm_thread_needed( false ),
-	_bm_thread_running( false ),
-	_bm_thread_should_exit( false ),
-	_time_diff_converged( false ),
-	_time_diff( 0 ),
-	_oflow( CRIMSON_TNG_TX_CHANNELS, 0 ),
-	_uflow( CRIMSON_TNG_TX_CHANNELS, 0 ),
-	_uoflow_report_en( false )
 {
     UHD_MSG(status) << "Opening a Crimson TNG device..." << std::endl;
     _type = device::CRIMSON_TNG;
@@ -1068,6 +1071,8 @@ bool crimson_tng_impl::recv_async_msg( uhd::async_metadata_t &async_metadata, do
 bool crimson_tng_impl::is_bm_thread_needed() {
 	bool r = true;
 
+	std::lock_guard<std::mutex> _lock( _bm_thread_mutex );
+
 #ifndef __APPLE__ // eventually use something like HAVE_PROGRAM_INVOCATION_NAME
 	static const std::vector<std::string> utils {
 		"uhd_find_devices",
@@ -1082,6 +1087,10 @@ bool crimson_tng_impl::is_bm_thread_needed() {
 			r = false;
 			break;
 		}
+	}
+
+	if ( _bm_thread_running ) {
+		r = false;
 	}
 
 #endif

--- a/host/lib/usrp/crimson_tng/crimson_tng_impl.hpp
+++ b/host/lib/usrp/crimson_tng/crimson_tng_impl.hpp
@@ -169,7 +169,7 @@ private:
 
 	// N.B: the _bm_thread is also used for clock domain synchronization
 	// N.B: the _bm_iface was removed in favour of using the _time_diff_iface
-	std::thread _bm_thread;
+	static std::thread _bm_thread;
 	static std::mutex _bm_thread_mutex;
 	static bool _bm_thread_needed;
 	static bool _bm_thread_running;

--- a/host/lib/usrp/crimson_tng/crimson_tng_impl.hpp
+++ b/host/lib/usrp/crimson_tng/crimson_tng_impl.hpp
@@ -85,8 +85,8 @@ public:
     void start_bm();
     void stop_bm();
 
-    static void bm_listener_add( uhd::crimson_tng_tx_streamer *listener );
-    static void bm_listener_rem( uhd::crimson_tng_tx_streamer *listener );
+    void bm_listener_add( uhd::crimson_tng_tx_streamer *listener );
+    void bm_listener_rem( uhd::crimson_tng_tx_streamer *listener );
 
     void uoflow_enable_reporting( bool en = true );
 
@@ -155,8 +155,8 @@ private:
 	 *     => Crimson Time Now := Host Time Now + CV
 	 */
 	uhd::pidc _time_diff_pidc;
-    static double _time_diff;
-	static bool _time_diff_converged;
+    double _time_diff;
+	bool _time_diff_converged;
 	uhd::time_spec_t _streamer_start_time;
     void time_diff_send( const uhd::time_spec_t & crimson_now );
     bool time_diff_recv( time_diff_resp & tdr );
@@ -167,21 +167,21 @@ private:
      * Buffer Management Objects
      */
 
+    std::set<uhd::crimson_tng_tx_streamer *> _bm_listeners;
+
 	// N.B: the _bm_thread is also used for clock domain synchronization
 	// N.B: the _bm_iface was removed in favour of using the _time_diff_iface
-	static std::thread _bm_thread;
-	static std::mutex _bm_thread_mutex;
-	static bool _bm_thread_needed;
-	static bool _bm_thread_running;
-	static bool _bm_thread_should_exit;
+	std::thread _bm_thread;
+	std::mutex _bm_thread_mutex;
+	bool _bm_thread_needed;
+	bool _bm_thread_running;
+	bool _bm_thread_should_exit;
 	static void bm_thread_fn( crimson_tng_impl *dev );
-	static bool is_bm_thread_needed();
+	bool is_bm_thread_needed();
 
-	static std::vector<uint64_t> _uflow;
-	static std::vector<uint64_t> _oflow;
-	static bool _uoflow_report_en;
-
-    static std::set<uhd::crimson_tng_tx_streamer *> _bm_listeners;
+	std::vector<uint64_t> _uflow;
+	std::vector<uint64_t> _oflow;
+	bool _uoflow_report_en;
 };
 
 }

--- a/host/lib/usrp/crimson_tng/crimson_tng_impl.hpp
+++ b/host/lib/usrp/crimson_tng/crimson_tng_impl.hpp
@@ -171,10 +171,10 @@ private:
 
 	// N.B: the _bm_thread is also used for clock domain synchronization
 	// N.B: the _bm_iface was removed in favour of using the _time_diff_iface
-	std::thread _bm_thread;
-	std::mutex _bm_thread_mutex;
+	static std::thread _bm_thread;
+	static std::mutex _bm_thread_mutex;
+	static bool _bm_thread_running;
 	bool _bm_thread_needed;
-	bool _bm_thread_running;
 	bool _bm_thread_should_exit;
 	static void bm_thread_fn( crimson_tng_impl *dev );
 	bool is_bm_thread_needed();

--- a/host/lib/usrp/crimson_tng/crimson_tng_impl.hpp
+++ b/host/lib/usrp/crimson_tng/crimson_tng_impl.hpp
@@ -155,8 +155,8 @@ private:
 	 *     => Crimson Time Now := Host Time Now + CV
 	 */
 	uhd::pidc _time_diff_pidc;
-    double _time_diff;
-	bool _time_diff_converged;
+    static double _time_diff;
+	static bool _time_diff_converged;
 	uhd::time_spec_t _streamer_start_time;
     void time_diff_send( const uhd::time_spec_t & crimson_now );
     bool time_diff_recv( time_diff_resp & tdr );
@@ -172,16 +172,16 @@ private:
 	// N.B: the _bm_thread is also used for clock domain synchronization
 	// N.B: the _bm_iface was removed in favour of using the _time_diff_iface
 	std::thread _bm_thread;
-	std::mutex _bm_thread_mutex;
-	bool _bm_thread_needed;
-	bool _bm_thread_running;
-	bool _bm_thread_should_exit;
+	static std::mutex _bm_thread_mutex;
+	static bool _bm_thread_needed;
+	static bool _bm_thread_running;
+	static bool _bm_thread_should_exit;
 	static void bm_thread_fn( crimson_tng_impl *dev );
-	bool is_bm_thread_needed();
+	static bool is_bm_thread_needed();
 
-	std::vector<uint64_t> _uflow;
-	std::vector<uint64_t> _oflow;
-	bool _uoflow_report_en;
+	static std::vector<uint64_t> _uflow;
+	static std::vector<uint64_t> _oflow;
+	static bool _uoflow_report_en;
 };
 
 }

--- a/host/lib/usrp/crimson_tng/crimson_tng_impl.hpp
+++ b/host/lib/usrp/crimson_tng/crimson_tng_impl.hpp
@@ -31,6 +31,10 @@
 #include "crimson_tng_tx_streamer.hpp"
 #include "pidc.hpp"
 
+#ifndef DEBUG_BM
+//#define DEBUG_BM 1
+#endif
+
 namespace uhd {
 namespace usrp {
 

--- a/host/lib/usrp/crimson_tng/crimson_tng_impl.hpp
+++ b/host/lib/usrp/crimson_tng/crimson_tng_impl.hpp
@@ -85,8 +85,8 @@ public:
     void start_bm();
     void stop_bm();
 
-    void bm_listener_add( uhd::crimson_tng_tx_streamer *listener );
-    void bm_listener_rem( uhd::crimson_tng_tx_streamer *listener );
+    static void bm_listener_add( uhd::crimson_tng_tx_streamer *listener );
+    static void bm_listener_rem( uhd::crimson_tng_tx_streamer *listener );
 
     void uoflow_enable_reporting( bool en = true );
 
@@ -167,8 +167,6 @@ private:
      * Buffer Management Objects
      */
 
-    std::set<uhd::crimson_tng_tx_streamer *> _bm_listeners;
-
 	// N.B: the _bm_thread is also used for clock domain synchronization
 	// N.B: the _bm_iface was removed in favour of using the _time_diff_iface
 	std::thread _bm_thread;
@@ -182,6 +180,8 @@ private:
 	static std::vector<uint64_t> _uflow;
 	static std::vector<uint64_t> _oflow;
 	static bool _uoflow_report_en;
+
+    static std::set<uhd::crimson_tng_tx_streamer *> _bm_listeners;
 };
 
 }

--- a/host/lib/usrp/crimson_tng/crimson_tng_tx_streamer.cpp
+++ b/host/lib/usrp/crimson_tng/crimson_tng_tx_streamer.cpp
@@ -182,8 +182,6 @@ size_t crimson_tng_tx_streamer::send(
 	uhd::usrp::crimson_tng_impl *dev = static_cast<uhd::usrp::crimson_tng_impl *>( _dev );
 	dev->uoflow_enable_reporting();
 
-	//std::cout << "sending " << nsamps_per_buff << " samples per channel" << std::endl;
-
 	if (
 		true
 		&& false == _metadata.start_of_burst
@@ -197,31 +195,16 @@ size_t crimson_tng_tx_streamer::send(
 
 	tx_metadata_t md = _metadata;
 	if ( _first_send && _sob_arg > 0.0 ) {
-		//std::cout << "_first_send and _sob_arg is " << _sob_arg << std::endl;
 		md.has_time_spec = true;
 		md.time_spec = get_time_now() + _sob_arg;
 		//std::cout << "sending " <<  nsamps_per_buff << " samples in " << _sob_arg << " s" << std::endl;
 	}
-
 	// XXX: @CF: workaround for current overflow issue
 	// found that when SoB was zero, buffer level did not get up to set point. 
 	// suggested a minimal SoB to pre-fill the buffer.
 	if ( _first_send && ! md.has_time_spec ) {
-		//std::cout << "_first_send and ! md.has_time_spec" << std::endl;
 		md.has_time_spec = true;
 		md.time_spec = get_time_now() + 1.0;
-	}
-
-	if ( _first_send && 0 == nsamps_per_buff ) {
-		_saved_sob = md.time_spec.get_real_secs();
-		//std::cout << "_first_send and 0 == nsamps_per_buff. _saved_sob = " << _saved_sob << std::endl;
-		_first_send_was_0len = true;
-		return 0;
-	}
-	if ( _first_send_was_0len && nsamps_per_buff > 0 ) {
-		//std::cout << "_first_send_was_0len && nsamps_per_buff > 0. _saved_sob = " << _saved_sob << std::endl;
-		md.time_spec = _saved_sob;
-		_first_send_was_0len = false;
 	}
 
 	for ( size_t i = 0; i < _channels.size(); i++ ) {

--- a/host/lib/usrp/crimson_tng/crimson_tng_tx_streamer.cpp
+++ b/host/lib/usrp/crimson_tng/crimson_tng_tx_streamer.cpp
@@ -197,7 +197,6 @@ size_t crimson_tng_tx_streamer::send(
 	if ( _first_send && _sob_arg > 0.0 ) {
 		md.has_time_spec = true;
 		md.time_spec = get_time_now() + _sob_arg;
-		//std::cout << "sending " <<  nsamps_per_buff << " samples in " << _sob_arg << " s" << std::endl;
 	}
 	// XXX: @CF: workaround for current overflow issue
 	// found that when SoB was zero, buffer level did not get up to set point. 
@@ -216,6 +215,12 @@ size_t crimson_tng_tx_streamer::send(
 	}
 
 	now = get_time_now();
+
+#ifdef DEBUG_TX
+	if ( _first_send ) {
+		std::cout << __func__ << "(): Now: " << now.get_real_secs() << ", SoB: " << md.time_spec.get_real_secs() << std::endl;;
+	}
+#endif
 
 	send_deadline = now;
 	send_deadline += timeout;
@@ -280,6 +285,12 @@ size_t crimson_tng_tx_streamer::send(
 				// nop
 				__asm__ __volatile__( "" );
 			}
+#ifdef DEBUG_TX
+	if ( _first_send ) {
+		std::cout << __func__ << "(): Now: " << now.get_real_secs() << std::endl;
+		_first_send = false;
+	}
+#endif
 
 			//
 			// Ensure that we have primed the buffers if SoB was given

--- a/host/lib/usrp/crimson_tng/crimson_tng_tx_streamer.cpp
+++ b/host/lib/usrp/crimson_tng/crimson_tng_tx_streamer.cpp
@@ -225,12 +225,16 @@ size_t crimson_tng_tx_streamer::send(
 		;
 		true
 		&& get_time_now() < send_deadline
-		&& samp_sent < nsamps_per_buff * _channels.size()
+		&& (
+			false
+			|| samp_sent < nsamps_per_buff * _channels.size()
+			|| 0 == nsamps_per_buff
+		)
 		;
 	) {
 		for ( size_t i = 0; i < _channels.size(); i++ ) {
 
-			if ( 0 == remaining_bytes[ i ] ) {
+			if ( 0 == remaining_bytes[ i ] && 0 != nsamps_per_buff ) {
 				continue;
 			}
 
@@ -343,6 +347,10 @@ size_t crimson_tng_tx_streamer::send(
 
 			// this ensures we only send the vita time spec on the first packet of the burst
 			metadata[ i ].has_time_spec = false;
+		}
+
+		if ( 0 == nsamps_per_buff ) {
+			break;
 		}
 	}
 

--- a/host/lib/usrp/crimson_tng/crimson_tng_tx_streamer.cpp
+++ b/host/lib/usrp/crimson_tng/crimson_tng_tx_streamer.cpp
@@ -182,6 +182,8 @@ size_t crimson_tng_tx_streamer::send(
 	uhd::usrp::crimson_tng_impl *dev = static_cast<uhd::usrp::crimson_tng_impl *>( _dev );
 	dev->uoflow_enable_reporting();
 
+	//std::cout << "sending " << nsamps_per_buff << " samples per channel" << std::endl;
+
 	if (
 		true
 		&& false == _metadata.start_of_burst
@@ -195,16 +197,31 @@ size_t crimson_tng_tx_streamer::send(
 
 	tx_metadata_t md = _metadata;
 	if ( _first_send && _sob_arg > 0.0 ) {
+		//std::cout << "_first_send and _sob_arg is " << _sob_arg << std::endl;
 		md.has_time_spec = true;
 		md.time_spec = get_time_now() + _sob_arg;
 		//std::cout << "sending " <<  nsamps_per_buff << " samples in " << _sob_arg << " s" << std::endl;
 	}
+
 	// XXX: @CF: workaround for current overflow issue
 	// found that when SoB was zero, buffer level did not get up to set point. 
 	// suggested a minimal SoB to pre-fill the buffer.
 	if ( _first_send && ! md.has_time_spec ) {
+		//std::cout << "_first_send and ! md.has_time_spec" << std::endl;
 		md.has_time_spec = true;
 		md.time_spec = get_time_now() + 1.0;
+	}
+
+	if ( _first_send && 0 == nsamps_per_buff ) {
+		_saved_sob = md.time_spec.get_real_secs();
+		//std::cout << "_first_send and 0 == nsamps_per_buff. _saved_sob = " << _saved_sob << std::endl;
+		_first_send_was_0len = true;
+		return 0;
+	}
+	if ( _first_send_was_0len && nsamps_per_buff > 0 ) {
+		//std::cout << "_first_send_was_0len && nsamps_per_buff > 0. _saved_sob = " << _saved_sob << std::endl;
+		md.time_spec = _saved_sob;
+		_first_send_was_0len = false;
 	}
 
 	for ( size_t i = 0; i < _channels.size(); i++ ) {

--- a/host/lib/usrp/crimson_tng/crimson_tng_tx_streamer.cpp
+++ b/host/lib/usrp/crimson_tng/crimson_tng_tx_streamer.cpp
@@ -184,7 +184,6 @@ size_t crimson_tng_tx_streamer::send(
 
 	if (
 		true
-		&& false == _metadata.start_of_burst
 		&& true == _metadata.end_of_burst
 		&& 0 == nsamps_per_buff
 	) {
@@ -215,12 +214,6 @@ size_t crimson_tng_tx_streamer::send(
 	}
 
 	now = get_time_now();
-
-#ifdef DEBUG_TX
-	if ( _first_send ) {
-		std::cout << __func__ << "(): Now: " << now.get_real_secs() << ", SoB: " << md.time_spec.get_real_secs() << std::endl;;
-	}
-#endif
 
 	send_deadline = now;
 	send_deadline += timeout;
@@ -285,12 +278,6 @@ size_t crimson_tng_tx_streamer::send(
 				// nop
 				__asm__ __volatile__( "" );
 			}
-#ifdef DEBUG_TX
-	if ( _first_send ) {
-		std::cout << __func__ << "(): Now: " << now.get_real_secs() << std::endl;
-		_first_send = false;
-	}
-#endif
 
 			//
 			// Ensure that we have primed the buffers if SoB was given

--- a/host/lib/usrp/crimson_tng/crimson_tng_tx_streamer.hpp
+++ b/host/lib/usrp/crimson_tng/crimson_tng_tx_streamer.hpp
@@ -30,8 +30,6 @@ public:
 		_max_clock_ppm_error( 0.0 ),
 		_dev( NULL ),
 		_first_send( true ),
-		_first_send_was_0len( false ),
-		_saved_sob( 0.0 ),
 		_sob_arg( 0.0 )
 	{
 		init_tx_streamer( addr, tree, channels );
@@ -94,8 +92,6 @@ private:
 	double _max_clock_ppm_error;
 	uint32_t _vita_hdr_buf[ 16 ];
 	bool _first_send;
-	bool _first_send_was_0len;
-	double _saved_sob;
 	double _sob_arg;
 
 	/// Store results of time diff in _crimson_tng_impl object

--- a/host/lib/usrp/crimson_tng/crimson_tng_tx_streamer.hpp
+++ b/host/lib/usrp/crimson_tng/crimson_tng_tx_streamer.hpp
@@ -30,6 +30,8 @@ public:
 		_max_clock_ppm_error( 0.0 ),
 		_dev( NULL ),
 		_first_send( true ),
+		_first_send_was_0len( false ),
+		_saved_sob( 0.0 ),
 		_sob_arg( 0.0 )
 	{
 		init_tx_streamer( addr, tree, channels );
@@ -92,6 +94,8 @@ private:
 	double _max_clock_ppm_error;
 	uint32_t _vita_hdr_buf[ 16 ];
 	bool _first_send;
+	bool _first_send_was_0len;
+	double _saved_sob;
 	double _sob_arg;
 
 	/// Store results of time diff in _crimson_tng_impl object

--- a/host/lib/usrp/crimson_tng/crimson_tng_tx_streamer.hpp
+++ b/host/lib/usrp/crimson_tng/crimson_tng_tx_streamer.hpp
@@ -13,7 +13,7 @@
 #include "flow_control.hpp"
 
 #ifndef DEBUG_TX
-#define DEBUG_TX 1
+//#define DEBUG_TX 1
 #endif
 
 namespace uhd {


### PR DESCRIPTION
* strengthen the case for single buffer management thread (was already working, this is just a bit more proper)
* remove requirement for start_of_burst = false for mini EOB packet