### PR TITLE
Kb/4112/uhd sefault on mutex operation

### DIFF
--- a/host/lib/usrp/crimson_tng/crimson_tng_impl.cpp
+++ b/host/lib/usrp/crimson_tng/crimson_tng_impl.cpp
@@ -479,11 +479,12 @@ void crimson_tng_impl::fifo_update_process( const time_diff_resp & tdr ) {
 		fifo_lvl[ j ] = tdr.fifo[ CRIMSON_TNG_TX_CHANNELS - j - 1 ];
 	}
 
-		_bm_thread_mutex.try_lock();{
+	if ( _bm_thread_mutex.try_lock() ) {
 		for( auto & l: _bm_listeners ) {
 			l->on_buffer_level_read( fifo_lvl );
 		}
-		_bm_thread_mutex.unlock();}
+		_bm_thread_mutex.unlock();
+	}
 }
 
 static void print_bm_starting() {

--- a/host/lib/usrp/crimson_tng/crimson_tng_impl.cpp
+++ b/host/lib/usrp/crimson_tng/crimson_tng_impl.cpp
@@ -473,17 +473,16 @@ void crimson_tng_impl::time_diff_process( const time_diff_resp & tdr, const uhd:
 
 void crimson_tng_impl::fifo_update_process( const time_diff_resp & tdr ) {
 
+	std::lock_guard<std::mutex> _lock( _bm_thread_mutex );
+
 	// for now we have to copy the fifo levels into a std::vector<size_t> for processing
 	std::vector<size_t> fifo_lvl( CRIMSON_TNG_TX_CHANNELS, 0 );
 	for( int j = 0; j < CRIMSON_TNG_TX_CHANNELS; j++ ) {
 		fifo_lvl[ j ] = tdr.fifo[ CRIMSON_TNG_TX_CHANNELS - j - 1 ];
 	}
 
-	if ( _bm_thread_mutex.try_lock() ) {
-		for( auto & l: _bm_listeners ) {
-			l->on_buffer_level_read( fifo_lvl );
-		}
-		_bm_thread_mutex.unlock();
+	for( auto & l: _bm_listeners ) {
+		l->on_buffer_level_read( fifo_lvl );
 	}
 }
 


### PR DESCRIPTION
The reported bug was initially conflated with another intel microcode bug, but it was really just incorrect program flow. The scoped lock works as well and is cleaner.