### PR TITLE
Support setting arbitrary crimson properties via device_addr_t

### DIFF
--- a/host/examples/rx_timed_samples_crimson.cpp
+++ b/host/examples/rx_timed_samples_crimson.cpp
@@ -58,8 +58,6 @@ int UHD_SAFE_MAIN(int argc, char *argv[]){
 
     bool verbose = vm.count("dilv") == 0;
 
-    args += ", crimson:rx/d/link/mac_dest=00:11:22:33:44:55";
-
     //create a usrp device
     std::cout << std::endl;
     std::cout << boost::format("Creating the usrp device with: %s...") % args << std::endl;

--- a/host/examples/rx_timed_samples_crimson.cpp
+++ b/host/examples/rx_timed_samples_crimson.cpp
@@ -58,7 +58,7 @@ int UHD_SAFE_MAIN(int argc, char *argv[]){
 
     bool verbose = vm.count("dilv") == 0;
 
-    args += ", crimson:/rx/d/link/mac_dest=00:11:22:33:44:55";
+    args += ", crimson:rx/d/link/mac_dest=00:11:22:33:44:55";
 
     //create a usrp device
     std::cout << std::endl;

--- a/host/examples/rx_timed_samples_crimson.cpp
+++ b/host/examples/rx_timed_samples_crimson.cpp
@@ -58,6 +58,8 @@ int UHD_SAFE_MAIN(int argc, char *argv[]){
 
     bool verbose = vm.count("dilv") == 0;
 
+    args += ", crimson:/rx/d/link/mac_dest=00:11:22:33:44:55";
+
     //create a usrp device
     std::cout << std::endl;
     std::cout << boost::format("Creating the usrp device with: %s...") % args << std::endl;

--- a/host/lib/usrp/crimson_tng/crimson_tng_impl.cpp
+++ b/host/lib/usrp/crimson_tng/crimson_tng_impl.cpp
@@ -211,20 +211,9 @@ void crimson_tng_impl::set_time_spec(const std::string pre, time_spec_t data) {
 void crimson_tng_impl::set_properties_from_addr() {
 	static const std::string crimson_prop_prefix( "crimson:" );
 	for( auto & prop: _addr.keys() ) {
-
-		std::string k = prop;
-		std::string v = _addr[ k ];
-
-		UHD_MSG( status )
-			<< __func__ << "(): "
-			<< "k: '"<< k << "', "
-			<< "v: '" << _addr.get( k ) << "'"
-			<< std::endl;
-
-
 		if ( 0 == prop.compare( 0, crimson_prop_prefix.length(), crimson_prop_prefix ) ) {
 			std::string key = prop.substr( crimson_prop_prefix.length() );
-			std::string expected_string = _addr.get( key );
+			std::string expected_string = _addr[ prop ];
 
 			UHD_MSG( error )
 				<< __func__ << "(): "

--- a/host/lib/usrp/crimson_tng/crimson_tng_impl.cpp
+++ b/host/lib/usrp/crimson_tng/crimson_tng_impl.cpp
@@ -211,9 +211,20 @@ void crimson_tng_impl::set_time_spec(const std::string pre, time_spec_t data) {
 void crimson_tng_impl::set_properties_from_addr() {
 	static const std::string crimson_prop_prefix( "crimson:" );
 	for( auto & prop: _addr.keys() ) {
+
+		std::string k = prop;
+		std::string v = _addr[ k ];
+
+		UHD_MSG( status )
+			<< __func__ << "(): "
+			<< "k: '"<< k << "', "
+			<< "v: '" << _addr.get( k ) << "'"
+			<< std::endl;
+
+
 		if ( 0 == prop.compare( 0, crimson_prop_prefix.length(), crimson_prop_prefix ) ) {
 			std::string key = prop.substr( crimson_prop_prefix.length() );
-			std::string expected_string = _addr[ key ];
+			std::string expected_string = _addr.get( key );
 
 			UHD_MSG( error )
 				<< __func__ << "(): "

--- a/host/lib/usrp/crimson_tng/crimson_tng_impl.cpp
+++ b/host/lib/usrp/crimson_tng/crimson_tng_impl.cpp
@@ -254,12 +254,12 @@ tx_streamer::sptr crimson_tng_impl::get_tx_stream(const uhd::stream_args_t &args
 			\"sc16\" Q16 I16" << std::endl;
 	}
 
+	set_properties_from_addr();
+
 	// TODO firmware support for other otw_format, cpu_format
 	crimson_tng_tx_streamer::sptr r( new uhd::crimson_tng_tx_streamer( this->_addr, this->_tree, args.channels ) );
 	r->set_device( static_cast<uhd::device *>( this ) );
 	bm_listener_add( (crimson_tng_tx_streamer *) r.get() );
-
-	set_properties_from_addr();
 
 	return r;
 }
@@ -280,10 +280,10 @@ rx_streamer::sptr crimson_tng_impl::get_rx_stream(const uhd::stream_args_t &args
 			\"sc16\" Q16 I16" << std::endl;
 	}
 
+	set_properties_from_addr();
+
 	crimson_tng_rx_streamer::sptr r( new uhd::crimson_tng_rx_streamer( this->_addr, this->_tree, args.channels ) );
 	r->set_device( static_cast<uhd::device *>( this ) );
-
-	set_properties_from_addr();
 
 	return r;
 }

--- a/host/lib/usrp/crimson_tng/crimson_tng_impl.cpp
+++ b/host/lib/usrp/crimson_tng/crimson_tng_impl.cpp
@@ -208,6 +208,35 @@ void crimson_tng_impl::set_time_spec(const std::string pre, time_spec_t data) {
 	return;
 }
 
+void crimson_tng_impl::set_properties_from_addr() {
+	static const std::string crimson_prop_prefix( "crimson:" );
+	for( auto & prop: _addr.keys() ) {
+		if ( 0 == prop.compare( 0, crimson_prop_prefix.length(), crimson_prop_prefix ) ) {
+			std::string key = prop.substr( crimson_prop_prefix.length() );
+			std::string expected_string = _addr[ key ];
+
+			UHD_MSG( error )
+				<< __func__ << "(): "
+				<< "Setting Crimson property: "
+				<< "key: '"<< key << "', "
+				<< "val: '" << expected_string << "'"
+				<< std::endl;
+
+			set_string( key, expected_string );
+
+			std::string actual_string = get_string( key );
+			if ( actual_string != expected_string ) {
+				UHD_MSG( error )
+					<< __func__ << "(): "
+					<< "Setting Crimson property failed: "
+					<< "key: '"<< key << "', "
+					<< "expected val: '" << expected_string << "', "
+					<< "actual val: '" << actual_string  << "'"
+					<< std::endl;
+			}
+		}
+	}
+}
 
 /***********************************************************************
  * Transmit streamer
@@ -229,6 +258,9 @@ tx_streamer::sptr crimson_tng_impl::get_tx_stream(const uhd::stream_args_t &args
 	crimson_tng_tx_streamer::sptr r( new uhd::crimson_tng_tx_streamer( this->_addr, this->_tree, args.channels ) );
 	r->set_device( static_cast<uhd::device *>( this ) );
 	bm_listener_add( (crimson_tng_tx_streamer *) r.get() );
+
+	set_properties_from_addr();
+
 	return r;
 }
 
@@ -250,6 +282,9 @@ rx_streamer::sptr crimson_tng_impl::get_rx_stream(const uhd::stream_args_t &args
 
 	crimson_tng_rx_streamer::sptr r( new uhd::crimson_tng_rx_streamer( this->_addr, this->_tree, args.channels ) );
 	r->set_device( static_cast<uhd::device *>( this ) );
+
+	set_properties_from_addr();
+
 	return r;
 }
 

--- a/host/lib/usrp/crimson_tng/crimson_tng_impl.cpp
+++ b/host/lib/usrp/crimson_tng/crimson_tng_impl.cpp
@@ -215,12 +215,12 @@ void crimson_tng_impl::set_properties_from_addr() {
 			std::string key = prop.substr( crimson_prop_prefix.length() );
 			std::string expected_string = _addr[ prop ];
 
-			UHD_MSG( error )
-				<< __func__ << "(): "
-				<< "Setting Crimson property: "
-				<< "key: '"<< key << "', "
-				<< "val: '" << expected_string << "'"
-				<< std::endl;
+//			UHD_MSG( status )
+//				<< __func__ << "(): "
+//				<< "Setting Crimson property: "
+//				<< "key: '"<< key << "', "
+//				<< "val: '" << expected_string << "'"
+//				<< std::endl;
 
 			set_string( key, expected_string );
 

--- a/host/lib/usrp/crimson_tng/crimson_tng_impl.hpp
+++ b/host/lib/usrp/crimson_tng/crimson_tng_impl.hpp
@@ -152,6 +152,9 @@ private:
     uhd::time_spec_t get_time_spec(std::string req);
     void set_time_spec(const std::string pre, uhd::time_spec_t data);
 
+    // set arbitrary crimson properties from dev_addr_t using mappings of the form "crimson:key" => "val"
+    void set_properties_from_addr();
+
     // private pointer to the UDP interface, this is the path to send commands to Crimson
     uhd::crimson_tng_iface::sptr _iface;
     std::mutex _iface_lock;


### PR DESCRIPTION
Support setting arbitrary crimson properties via device_addr_t. This obviously only works upon init so it's usefulness is somewhat limited, but it should be fine for networking concerns.

Usage: e.g.

args += ", crimson:fpga/link/sfpa/pay_len=8000";
args += ", crimson:rx/b/link/port=1234";
args += ", crimson:rx/d/link/mac_dest=00:11:22:33:44:55";