### PR TITLE
use default mtu of 1500 when "ip route show to match <ip>" fails

### DIFF
--- a/host/lib/usrp/crimson_tng/iputils.hpp
+++ b/host/lib/usrp/crimson_tng/iputils.hpp
@@ -226,8 +226,14 @@ public:
 		std::string iface;
 		std::string local_addr;
 
-		get_route( remote_addr, iface, local_addr );
-		size_t mtu = get_mtu( iface );
+		size_t mtu = 1500;
+
+		try {
+			get_route( remote_addr, iface, local_addr );
+			mtu = get_mtu( iface );
+		} catch( ... ) {
+			std::cerr << "Unable to determine default route to %s and, subsequently, interface mtu. Defaulting to " << mtu << std::endl;
+		}
 
 		return mtu;
 	}


### PR DESCRIPTION
I have not been able to isolate the locale as being the source of error in this case. Also, if the 'ip' command is not present, we would see a different error, so that is not the issue. For some reason, the output of "ip route show to match 10.10.10.2" does not contain a line beginning with the string "default via".