### PR TITLE
Kb/4307/uhd add sob argument for rx

### DIFF
--- a/host/examples/rx_timed_samples_crimson.cpp
+++ b/host/examples/rx_timed_samples_crimson.cpp
@@ -60,6 +60,7 @@ int UHD_SAFE_MAIN(int argc, char *argv[]){
 
     //create a usrp device
     std::cout << std::endl;
+    args += ", crimson:sob=20";
     std::cout << boost::format("Creating the usrp device with: %s...") % args << std::endl;
     uhd::usrp::multi_usrp::sptr usrp = uhd::usrp::multi_usrp::make(args);
     std::cout << boost::format("Using Device: %s") % usrp->get_pp_string() << std::endl;
@@ -90,14 +91,16 @@ int UHD_SAFE_MAIN(int argc, char *argv[]){
     uhd::rx_streamer::sptr rx_stream = usrp->get_rx_stream(stream_args);
 
     //setup streaming
-    std::cout << std::endl;
-    std::cout << boost::format(
-        "Begin streaming %u samples, %f seconds in the future..."
-    ) % total_num_samps % seconds_in_future << std::endl;
     uhd::stream_cmd_t stream_cmd(uhd::stream_cmd_t::STREAM_MODE_NUM_SAMPS_AND_DONE);
     stream_cmd.num_samps = total_num_samps;
-    stream_cmd.stream_now = false;
-    stream_cmd.time_spec = usrp->get_time_now() + seconds_in_future;
+    if ( seconds_in_future > 0 ) {
+        std::cout << std::endl;
+		std::cout << boost::format(
+			"Begin streaming %u samples, %f seconds in the future..."
+		) % total_num_samps % seconds_in_future << std::endl;
+	    stream_cmd.stream_now = false;
+	    stream_cmd.time_spec = usrp->get_time_now() + seconds_in_future;
+    }
     rx_stream->issue_stream_cmd(stream_cmd);
 
     //meta-data will be filled in by recv()

--- a/host/examples/rx_timed_samples_crimson.cpp
+++ b/host/examples/rx_timed_samples_crimson.cpp
@@ -60,7 +60,8 @@ int UHD_SAFE_MAIN(int argc, char *argv[]){
 
     //create a usrp device
     std::cout << std::endl;
-    args += ", crimson:sob=20";
+    // use --secs=0 and uncomment the line below to demonstrate setting SoB through device_addr_t arguments
+    // args += ", crimson:sob=20";
     std::cout << boost::format("Creating the usrp device with: %s...") % args << std::endl;
     uhd::usrp::multi_usrp::sptr usrp = uhd::usrp::multi_usrp::make(args);
     std::cout << boost::format("Using Device: %s") % usrp->get_pp_string() << std::endl;
@@ -100,6 +101,8 @@ int UHD_SAFE_MAIN(int argc, char *argv[]){
 		) % total_num_samps % seconds_in_future << std::endl;
 	    stream_cmd.stream_now = false;
 	    stream_cmd.time_spec = usrp->get_time_now() + seconds_in_future;
+    } else {
+        stream_cmd.stream_now = true;
     }
     rx_stream->issue_stream_cmd(stream_cmd);
 

--- a/host/lib/usrp/crimson_tng/crimson_tng_impl.cpp
+++ b/host/lib/usrp/crimson_tng/crimson_tng_impl.cpp
@@ -209,9 +209,23 @@ void crimson_tng_impl::set_time_spec(const std::string pre, time_spec_t data) {
 }
 
 void crimson_tng_impl::set_properties_from_addr() {
+
 	static const std::string crimson_prop_prefix( "crimson:" );
+	static const std::vector<std::string> blacklist { "crimson:sob" };
+
 	for( auto & prop: _addr.keys() ) {
 		if ( 0 == prop.compare( 0, crimson_prop_prefix.length(), crimson_prop_prefix ) ) {
+
+			bool is_blacklisted = false;
+			for( auto & e: blacklist ) {
+				if ( e == prop ) {
+					is_blacklisted = true;
+				}
+			}
+			if ( is_blacklisted ) {
+				continue;
+			}
+
 			std::string key = prop.substr( crimson_prop_prefix.length() );
 			std::string expected_string = _addr[ prop ];
 

--- a/host/lib/usrp/crimson_tng/crimson_tng_rx_streamer.cpp
+++ b/host/lib/usrp/crimson_tng/crimson_tng_rx_streamer.cpp
@@ -344,14 +344,6 @@ void crimson_tng_rx_streamer::init_rx_streamer(device_addr_t addr, property_tree
 	_fifo = std::vector<std::queue<uint8_t>>( _channels.size() );
 	_stream_cmd_samples_remaining = std::vector<size_t>( _channels.size() );
 
-	if ( addr.has_key( "sync_multichannel_params" ) && "1" == addr[ "sync_multichannel_params" ] ) {
-		std::bitset<32> bs;
-		for( auto & ch: _channels ) {
-			bs.set( ch );
-		}
-		tree->access<int>( mb_path / "cm" / "chanmask-rx" ).set( bs.to_ulong() );
-	}
-
 	for (unsigned int i = 0; i < _channels.size(); i++) {
 		// get the channel parameters
 		std::string ch       = boost::lexical_cast<std::string>((char)(_channels[i] + 65));

--- a/host/lib/usrp/crimson_tng/crimson_tng_rx_streamer.cpp
+++ b/host/lib/usrp/crimson_tng/crimson_tng_rx_streamer.cpp
@@ -284,6 +284,12 @@ void crimson_tng_rx_streamer::issue_stream_cmd(const stream_cmd_t &stream_cmd) {
 	// store the _stream_cmd so that recv() can use it
 	_stream_cmd = stream_cmd;
 
+	if ( stream_cmd_t::STREAM_MODE_START_CONTINUOUS != _stream_cmd.stream_mode ) {
+		for( size_t i = 0; i < _channels.size(); i++ ) {
+			_tree->access<std::string>(rx_link_root( _channels[ i ] ) / "stream").set( "0" );
+		}
+	}
+
 	if ( stream_cmd_t::STREAM_MODE_STOP_CONTINUOUS == _stream_cmd.stream_mode ) {
 		stream_prop = "0";
 	} else {

--- a/host/lib/usrp/crimson_tng/crimson_tng_rx_streamer.hpp
+++ b/host/lib/usrp/crimson_tng/crimson_tng_rx_streamer.hpp
@@ -31,7 +31,9 @@ public:
 		_rate( 0.0 ),
 		_start_ticks( 0 ),
 		_dev( NULL ),
-		_stream_cmd( uhd::stream_cmd_t::STREAM_MODE_STOP_CONTINUOUS )
+		_stream_cmd( uhd::stream_cmd_t::STREAM_MODE_STOP_CONTINUOUS ),
+		_first_recv( true ),
+		_sob_arg( 0.0 )
 	{
 		init_rx_streamer( addr, tree, channels );
 	}
@@ -85,6 +87,8 @@ private:
 	double _rate;
 	uint64_t _start_ticks;
 	device_addr_t _addr;
+	bool _first_recv;
+	double _sob_arg;
 
 	uhd::device *_dev;
 

--- a/host/lib/usrp/crimson_tng/crimson_tng_rx_streamer.hpp
+++ b/host/lib/usrp/crimson_tng/crimson_tng_rx_streamer.hpp
@@ -24,6 +24,8 @@ class crimson_tng_rx_streamer : public uhd::rx_streamer {
 public:
 	typedef boost::shared_ptr<crimson_tng_rx_streamer> sptr;
 
+	static const size_t ALL_CHANS = ~0;
+
 	crimson_tng_rx_streamer( device_addr_t addr, property_tree::sptr tree, std::vector<size_t> channels )
 	:
 		_prev_frame( 0 ),
@@ -60,6 +62,8 @@ public:
     void issue_stream_cmd( const stream_cmd_t &stream_cmd );
 
 	void update_fifo_metadata( rx_metadata_t &meta, size_t n_samples );
+	void clear_fifo( size_t chan = ALL_CHANS );
+	void flush_socket( size_t chan = ALL_CHANS );
 
 	void set_device( uhd::device *dev ) {
 		_dev = dev;

--- a/host/lib/usrp/crimson_tng/crimson_tng_tx_streamer.cpp
+++ b/host/lib/usrp/crimson_tng/crimson_tng_tx_streamer.cpp
@@ -391,10 +391,9 @@ void crimson_tng_tx_streamer::init_tx_streamer(
 	_sample_count = std::vector<size_t>( _channels.size() );
 
 	if ( addr.has_key( "crimson:sob" )  ) {
-		//std::cout << "_sob_s=" << addr[ "sob_s" ] << std::endl;
-		double d = std::atof( addr[ "crimson:sob" ].c_str() );
-		_sob_arg = d >= 0.0 ? d : 0.0;
-		//std::cout << "set _sob_arg = " << _sob_arg << " s" << std::endl;
+		if ( ! sscanf( addr[ "crimson:sob" ].c_str(), "%lf", & _sob_arg ) ) {
+			UHD_MSG( warning )  << __func__ << "(): Unrecognized argument crimson:sob=" << addr[ "crimson:sob" ] << std::endl;
+		}
 	}
 
 	//Set up constants

--- a/host/lib/usrp/crimson_tng/crimson_tng_tx_streamer.cpp
+++ b/host/lib/usrp/crimson_tng/crimson_tng_tx_streamer.cpp
@@ -390,9 +390,9 @@ void crimson_tng_tx_streamer::init_tx_streamer(
 	_if_mtu = std::vector<size_t>( _channels.size() );
 	_sample_count = std::vector<size_t>( _channels.size() );
 
-	if ( addr.has_key( "sob_s" )  ) {
+	if ( addr.has_key( "crimson:sob" )  ) {
 		//std::cout << "_sob_s=" << addr[ "sob_s" ] << std::endl;
-		double d = std::atof( addr[ "sob_s" ].c_str() );
+		double d = std::atof( addr[ "crimson:sob" ].c_str() );
 		_sob_arg = d >= 0.0 ? d : 0.0;
 		//std::cout << "set _sob_arg = " << _sob_arg << " s" << std::endl;
 	}

--- a/host/lib/usrp/crimson_tng/crimson_tng_tx_streamer.cpp
+++ b/host/lib/usrp/crimson_tng/crimson_tng_tx_streamer.cpp
@@ -390,14 +390,6 @@ void crimson_tng_tx_streamer::init_tx_streamer(
 	_if_mtu = std::vector<size_t>( _channels.size() );
 	_sample_count = std::vector<size_t>( _channels.size() );
 
-	if ( addr.has_key( "sync_multichannel_params" ) && "1" == addr[ "sync_multichannel_params" ] ) {
-		std::bitset<32> bs;
-		for( auto & ch: _channels ) {
-			bs.set( ch );
-		}
-		tree->access<int>( mb_path / "cm" / "chanmask-tx" ).set( bs.to_ulong() );
-	}
-
 	if ( addr.has_key( "sob_s" )  ) {
 		//std::cout << "_sob_s=" << addr[ "sob_s" ] << std::endl;
 		double d = std::atof( addr[ "sob_s" ].c_str() );


### PR DESCRIPTION
* remove sync_multichannel_params argument parsing
* change tx sob arg string to crimson:sob
* add rx crimson:sob
* flush receive socket in while loop until empty (previously stream_in() was called only once!)
* added clear_fifo() and flush_socket()
* ensure stream is disabled before calling flush_socket
* used boost::endian::big_to_native_inplace() instead of manual byteswap in recv()
* filter non-property-tree arguments such as crimson:sob in set_properties_from_addr()