### PR TITLE
Repeatedly read output of popen when running ip route show to match

### DIFF
--- a/host/lib/usrp/crimson_tng/crimson_tng_tx_streamer.cpp
+++ b/host/lib/usrp/crimson_tng/crimson_tng_tx_streamer.cpp
@@ -442,7 +442,7 @@ void crimson_tng_tx_streamer::init_tx_streamer(
 		socklen_t remote_addr_len = sizeof( remote_addr ), local_addr_len = sizeof( local_addr );
 		int fd;
 
-		iputils::get_route( ip_addr, iface, local_addrs );
+		iputils::get_route( iputils::get_route_info( ip_addr ), iface, local_addrs );
 		iputils::to_sockaddr( ip_addr, (sockaddr *) & remote_addr, remote_addr_len );
 		((sockaddr_in *)& remote_addr )->sin_port = htons( port );
 		iputils::to_sockaddr( local_addrs, (sockaddr *) & local_addr, local_addr_len );

--- a/host/tests/iputils_test.cpp
+++ b/host/tests/iputils_test.cpp
@@ -5,6 +5,24 @@
 using namespace std;
 using namespace uhd;
 
+BOOST_AUTO_TEST_CASE( test_get_route_info ) {
+
+	std::string local_addr;
+	std::string remote_addr( "8.8.8.8" );
+
+	std::string expected_iface;
+	std::string actual_iface;
+
+	std::string expected_route_info;
+	std::string actual_route_info;
+
+	actual_route_info = iputils::get_route_info( remote_addr );
+	BOOST_CHECK_NE( expected_route_info, actual_route_info );
+
+	iputils::get_route( actual_route_info, actual_iface, local_addr );
+	BOOST_CHECK_NE( expected_iface, actual_iface );
+}
+
 BOOST_AUTO_TEST_CASE( test_get_route ) {
 
 	std::string local_addr;
@@ -13,7 +31,7 @@ BOOST_AUTO_TEST_CASE( test_get_route ) {
 	std::string expected_iface = "";
 	std::string actual_iface;
 
-	uhd::iputils::get_route( remote_addr, actual_iface, local_addr );
+	uhd::iputils::get_route( iputils::get_route_info( remote_addr ), actual_iface, local_addr );
 
 	BOOST_CHECK_NE( expected_iface, actual_iface );
 
@@ -30,11 +48,59 @@ BOOST_AUTO_TEST_CASE( test_get_mtu ) {
 	size_t expected_mtu = 1472;
 	size_t actual_mtu;
 
-	uhd::iputils::get_route( remote_addr, actual_iface, local_addr );
+	uhd::iputils::get_route( iputils::get_route_info( remote_addr ), actual_iface, local_addr );
 
 	BOOST_CHECK_NE( expected_iface, actual_iface );
 
 	actual_mtu = uhd::iputils::get_mtu( actual_iface );
 
 	BOOST_CHECK_GE( actual_mtu, expected_mtu );
+}
+
+
+BOOST_AUTO_TEST_CASE( prueba_uno ) {
+
+	// ip route show to match 10.10.10.2
+	std::stringstream ss;
+	ss << "default via 192.168.128.1 dev enp6s0 src 192.168.128.203 metric 203" << std::endl;
+	ss << "10.10.10.0/24 dev enp1s0f1 proto kernel scope link src 10.10.10.10" << std::endl;
+
+	std::string route_info = ss.str();
+
+	std::string remote_addr( "10.10.10.2" );
+
+	std::string expected_iface = "enp1s0f1";
+	std::string actual_iface;
+
+	std::string expected_addr( "10.10.10.10" );
+	std::string actual_addr;
+
+	uhd::iputils::get_route( route_info, actual_iface, actual_addr );
+
+	BOOST_CHECK_EQUAL( expected_iface, actual_iface );
+}
+
+BOOST_AUTO_TEST_CASE( prueba_dos ) {
+
+	// ip route show to match 10.10.10.2
+	std::stringstream ss;
+	ss << "default via 172.19.50.5 dev enp10s0  proto static  metric 100" << std::endl;
+	ss << "default via 192.168.10.2 dev enp0s31f6  proto static  metric 101" << std::endl;
+	ss << "default via 10.10.11.2 dev enp1s0f0  proto static  metric 102" << std::endl;
+	ss << "default via 10.10.10.2 dev enp1s0f1  proto static  metric 103" << std::endl;
+	ss << "10.10.10.0/24 dev enp1s0f1  proto kernel  scope link  src 10.10.10.10  metric 100" << std::endl;
+
+	std::string route_info = ss.str();
+
+	std::string remote_addr( "10.10.10.2" );
+
+	std::string expected_iface = "enp1s0f1";
+	std::string actual_iface;
+
+	std::string expected_addr( "10.10.10.10" );
+	std::string actual_addr;
+
+	uhd::iputils::get_route( route_info, actual_iface, actual_addr );
+
+	BOOST_CHECK_EQUAL( expected_iface, actual_iface );
 }


### PR DESCRIPTION
Previously, we were only calling fread() once, and that was
sufficient when the resutls of

ip route show to match 10.10.10.2

returned

default via 192.168.128.1 dev enp6s0 src 192.168.128.203 metric 203
10.10.10.0/24 dev enp1s0f1 proto kernel scope link src 10.10.10.10

However, one customer has several default routes configured.

default via 172.19.50.5 dev enp10s0  proto static  metric 100
default via 192.168.10.2 dev enp0s31f6  proto static  metric 101
default via 10.10.11.2 dev enp1s0f0  proto static  metric 102
default via 10.10.10.2 dev enp1s0f1  proto static  metric 103
10.10.10.0/24 dev enp1s0f1  proto kernel  scope link  src 10.10.10.10  metric 100

There really should be no reason to have a route via the SFP ports,
but our code should work regardless.

The main problem was that we only scanned 256 characters before.

Nowe we scan all of them.

The behaviour is still to use the last dev (iface) and src (addr)
reported.