### PR TITLE
Kb/4458/uhd consistent get time now

### DIFF
--- a/host/lib/usrp/crimson_tng/crimson_tng_impl.cpp
+++ b/host/lib/usrp/crimson_tng/crimson_tng_impl.cpp
@@ -250,9 +250,8 @@ void crimson_tng_impl::set_stream_cmd( const std::string pre, stream_cmd_t cmd )
 		uhd::usrp::rx_sob_req rx_sob;
 
 		uhd::time_spec_t now = get_time_now();
-		uhd::time_spec_t then = cmd.stream_now ? now : cmd.time_spec;
 
-		make_rx_sob_req_packet( then, ch, rx_sob );
+		make_rx_sob_req_packet( cmd, now, ch, rx_sob );
 		send_rx_sob_req( rx_sob );
 
 		_tree->access<std::string>( stream_path ).set( "1" );
@@ -526,18 +525,43 @@ static inline void make_time_diff_packet( time_diff_req & pkt, time_spec_t ts = 
 	boost::endian::native_to_big_inplace( (uint64_t &) pkt.tv_tick );
 }
 
-void crimson_tng_impl::make_rx_sob_req_packet( const uhd::time_spec_t & ts, const size_t channel, uhd::usrp::rx_sob_req & pkt ) {
+void crimson_tng_impl::make_rx_sob_req_packet( const uhd::stream_cmd_t & cmd, const uhd::time_spec_t & now, const size_t channel, uhd::usrp::rx_sob_req & pkt ) {
+
+    typedef boost::tuple<bool, bool, bool, bool> inst_t;
+    static const uhd::dict<stream_cmd_t::stream_mode_t, inst_t> mode_to_inst = boost::assign::map_list_of
+                                                            //reload, chain, samps, stop
+        (stream_cmd_t::STREAM_MODE_START_CONTINUOUS,   inst_t(true,  true,  false, false))
+        (stream_cmd_t::STREAM_MODE_STOP_CONTINUOUS,    inst_t(false, false, false, true))
+        (stream_cmd_t::STREAM_MODE_NUM_SAMPS_AND_DONE, inst_t(false, false, true,  false))
+        (stream_cmd_t::STREAM_MODE_NUM_SAMPS_AND_MORE, inst_t(false, true,  true,  false))
+    ;
+
 	pkt.header = 0x10000 + channel;
+
+    //setup the instruction flag values
+    bool inst_reload, inst_chain, inst_samps, inst_stop;
+    boost::tie(inst_reload, inst_chain, inst_samps, inst_stop) = mode_to_inst[cmd.stream_mode];
+
+    pkt.header |= inst_reload ? ( 0b1000LL << 36 ) : 0;
+    pkt.header |= inst_chain  ? ( 0b0100LL << 36 ) : 0;
+    pkt.header |= inst_samps  ? ( 0b0010LL << 36 ) : 0;
+    pkt.header |= inst_stop   ? ( 0b0001LL << 36 ) : 0;
+
+	uhd::time_spec_t ts = cmd.stream_now ? now : cmd.time_spec;
 	pkt.tv_sec = ts.get_full_secs();
 	pkt.tv_psec = ts.get_frac_secs() * 1e12;
+
+	pkt.nsamples = inst_samps ? cmd.num_samps : 0;
 
 //	std::cout << "header: " << std::hex << std::setw( 16 ) << std::setfill('0') << pkt.header << std::endl;
 //	std::cout << "tv_sec: " << std::dec << pkt.tv_sec << std::endl;
 //	std::cout << "tv_psec: " << std::dec << pkt.tv_psec << std::endl;
+//	std::cout << "nsampls: " << std::dec << pkt.nsamples << std::endl;
 
 	boost::endian::native_to_big_inplace( pkt.header );
 	boost::endian::native_to_big_inplace( (uint64_t &) pkt.tv_sec );
 	boost::endian::native_to_big_inplace( (uint64_t &) pkt.tv_psec );
+	boost::endian::native_to_big_inplace( (uint64_t &) pkt.nsamples );
 }
 
 void crimson_tng_impl::send_rx_sob_req( const rx_sob_req & req ) {

--- a/host/lib/usrp/crimson_tng/crimson_tng_impl.hpp
+++ b/host/lib/usrp/crimson_tng/crimson_tng_impl.hpp
@@ -38,7 +38,7 @@ namespace usrp {
 
 #pragma pack(push,1)
 struct time_diff_req {
-	uint64_t header; // 1 for time diff
+	uint64_t header;
 	int64_t tv_sec;
 	int64_t tv_tick;
 };
@@ -62,9 +62,10 @@ struct time_diff_resp {
 
 #pragma pack(push,1)
 struct rx_sob_req {
-    uint64_t header;
+    uint64_t header;   // 0x10000 for RX SoB
     int64_t tv_sec;    // when the SoB should take place
     int64_t tv_psec;   // when the SoB should take place (ps)
+    uint64_t nsamples;
 };
 #pragma pack(pop)
 
@@ -110,7 +111,7 @@ public:
     void bm_listener_rem( uhd::crimson_tng_tx_streamer *listener );
 
     void send_rx_sob_req( const rx_sob_req & req );
-    static void make_rx_sob_req_packet( const uhd::time_spec_t & ts, const size_t channel, uhd::usrp::rx_sob_req & pkt );
+    static void make_rx_sob_req_packet( const uhd::stream_cmd_t & cmd, const uhd::time_spec_t & now, const size_t channel, uhd::usrp::rx_sob_req & pkt );
 
 private:
     // helper functions to wrap send and recv as get and set

--- a/host/lib/usrp/multi_crimson_tng.cpp
+++ b/host/lib/usrp/multi_crimson_tng.cpp
@@ -483,19 +483,9 @@ std::string multi_crimson_tng::get_mboard_name(size_t mboard){
     return _tree->access<std::string>(mb_root(0) / "name").get();
 }
 
-static bool printed_get_time_now;
-
 // Get the current time on Crimson
 time_spec_t multi_crimson_tng::get_time_now(size_t mboard){
-	crimson_tng_impl::sptr dev = boost::static_pointer_cast<crimson_tng_impl>( _dev );
-	double diff = NULL == dev.get() ? 0 : dev.get()->time_diff_get();
-	if ( ! printed_get_time_now ) {
-		if ( NULL != dev.get() ) {
-			std::cout << "time diff is " << diff << std::endl;
-			printed_get_time_now = true;
-		}
-	}
-	return time_spec_t::get_system_time() + diff;
+	return _tree->access<time_spec_t>(mb_root(0) / "time/now").get();
 }
 
 // Get the time of the last PPS (pulse per second)


### PR DESCRIPTION
Merge after #99 

get_time_now() was being inconsistent when used through crimson_tng_multi. This patch puts the logic in one place (crimson_tng_impl). Multi goes through the property tree (for "now" this is done locally and is synchonized via the PID).

Also, it's likely that one of my tests was strange because set_time_now() was being called after getting the rx_streamer; the PID would need additional time to converge after that, which is why the extra loop was inserted in crimson_tng_impl::set_time_spec().