### PR TITLE
Kb/4463/uhd simplify crimson tng impl set stream cmd

### DIFF
--- a/host/lib/usrp/crimson_tng/crimson_tng_impl.cpp
+++ b/host/lib/usrp/crimson_tng/crimson_tng_impl.cpp
@@ -542,10 +542,10 @@ void crimson_tng_impl::make_rx_sob_req_packet( const uhd::stream_cmd_t & cmd, co
     bool inst_reload, inst_chain, inst_samps, inst_stop;
     boost::tie(inst_reload, inst_chain, inst_samps, inst_stop) = mode_to_inst[cmd.stream_mode];
 
-    pkt.header |= inst_reload ? ( 0b1000 << 20 ) : 0;
-    pkt.header |= inst_chain  ? ( 0b0100 << 20 ) : 0;
-    pkt.header |= inst_samps  ? ( 0b0010 << 20 ) : 0;
-    pkt.header |= inst_stop   ? ( 0b0001 << 20 ) : 0;
+    pkt.header |= inst_reload ? ( 0b1000LL << 36 ) : 0;
+    pkt.header |= inst_chain  ? ( 0b0100LL << 36 ) : 0;
+    pkt.header |= inst_samps  ? ( 0b0010LL << 36 ) : 0;
+    pkt.header |= inst_stop   ? ( 0b0001LL << 36 ) : 0;
 
 	uhd::time_spec_t ts = cmd.stream_now ? now : cmd.time_spec;
 	pkt.tv_sec = ts.get_full_secs();

--- a/host/lib/usrp/crimson_tng/crimson_tng_impl.hpp
+++ b/host/lib/usrp/crimson_tng/crimson_tng_impl.hpp
@@ -61,7 +61,7 @@ struct time_diff_resp {
 #pragma pack(pop)
 
 #pragma pack(push,1)
-struct rx_sob_req {
+struct rx_stream_cmd {
     uint64_t header;   // 0x10000 for RX SoB
     int64_t tv_sec;    // when the SoB should take place
     int64_t tv_psec;   // when the SoB should take place (ps)
@@ -110,8 +110,8 @@ public:
     void bm_listener_add( uhd::crimson_tng_tx_streamer *listener );
     void bm_listener_rem( uhd::crimson_tng_tx_streamer *listener );
 
-    void send_rx_sob_req( const rx_sob_req & req );
-    static void make_rx_sob_req_packet( const uhd::stream_cmd_t & cmd, const uhd::time_spec_t & now, const size_t channel, uhd::usrp::rx_sob_req & pkt );
+    void send_rx_stream_cmd_req( const rx_stream_cmd & req );
+    static void make_rx_stream_cmd_packet( const uhd::stream_cmd_t & cmd, const uhd::time_spec_t & now, const size_t channel, uhd::usrp::rx_stream_cmd & pkt );
 
 private:
     // helper functions to wrap send and recv as get and set

--- a/host/lib/usrp/crimson_tng/crimson_tng_impl.hpp
+++ b/host/lib/usrp/crimson_tng/crimson_tng_impl.hpp
@@ -38,7 +38,7 @@ namespace usrp {
 
 #pragma pack(push,1)
 struct time_diff_req {
-	uint64_t header; // 1 for time diff
+	uint64_t header;
 	int64_t tv_sec;
 	int64_t tv_tick;
 };
@@ -62,9 +62,10 @@ struct time_diff_resp {
 
 #pragma pack(push,1)
 struct rx_sob_req {
-    uint64_t header;
+    uint64_t header;   // 0x10000 for RX SoB
     int64_t tv_sec;    // when the SoB should take place
     int64_t tv_psec;   // when the SoB should take place (ps)
+    uint64_t nsamples;
 };
 #pragma pack(pop)
 
@@ -110,7 +111,7 @@ public:
     void bm_listener_rem( uhd::crimson_tng_tx_streamer *listener );
 
     void send_rx_sob_req( const rx_sob_req & req );
-    static void make_rx_sob_req_packet( const uhd::time_spec_t & ts, const size_t channel, uhd::usrp::rx_sob_req & pkt );
+    static void make_rx_sob_req_packet( const uhd::stream_cmd_t & cmd, const uhd::time_spec_t & now, const size_t channel, uhd::usrp::rx_sob_req & pkt );
 
 private:
     // helper functions to wrap send and recv as get and set

--- a/host/lib/usrp/multi_crimson_tng.cpp
+++ b/host/lib/usrp/multi_crimson_tng.cpp
@@ -483,19 +483,9 @@ std::string multi_crimson_tng::get_mboard_name(size_t mboard){
     return _tree->access<std::string>(mb_root(0) / "name").get();
 }
 
-static bool printed_get_time_now;
-
 // Get the current time on Crimson
 time_spec_t multi_crimson_tng::get_time_now(size_t mboard){
-	crimson_tng_impl::sptr dev = boost::static_pointer_cast<crimson_tng_impl>( _dev );
-	double diff = NULL == dev.get() ? 0 : dev.get()->time_diff_get();
-	if ( ! printed_get_time_now ) {
-		if ( NULL != dev.get() ) {
-			std::cout << "time diff is " << diff << std::endl;
-			printed_get_time_now = true;
-		}
-	}
-	return time_spec_t::get_system_time() + diff;
+	return _tree->access<time_spec_t>(mb_root(0) / "time/now").get();
 }
 
 // Get the time of the last PPS (pulse per second)


### PR DESCRIPTION
Merge after #100 

Now that we are processing RX Stream Commands on the FPGA, we can simplify the host-side processing required (i.e. we no longer need to toggle "/stream", or "/pwr").

Also, since our rx_sob_req is no longer just for SoB, I'm renaming them (and related functions) to "rx_stream_cmd" instead of "rx_sob_req".