### PR TITLE
Fix flow control with new TX api

### DIFF
--- a/host/lib/usrp/crimson_tng/crimson_tng_impl.cpp
+++ b/host/lib/usrp/crimson_tng/crimson_tng_impl.cpp
@@ -252,12 +252,14 @@ time_spec_t crimson_tng_impl::get_time_spec(std::string req) {
 		return temp;
 	}
 }
-void crimson_tng_impl::set_time_spec(const std::string pre, time_spec_t data) {
-	set_double(pre, (double)data.get_full_secs() + data.get_frac_secs());
-	if ( "time/clk/cur_time" == pre ) {
-		for( _time_diff_converged = false; ! _time_diff_converged; ) {
-			usleep( 100000 );
-		}
+void crimson_tng_impl::set_time_spec( const std::string key, time_spec_t value ) {
+	if ( "time/clk/cur_time" == key ) {
+		//std::cout << __func__ << "(): " << std::fixed << std::setprecision( 12 ) << value.get_real_secs() << std::endl;
+		stop_bm();
+	}
+	set_double(key, (double)value.get_full_secs() + value.get_frac_secs());
+	if ( "time/clk/cur_time" == key ) {
+		start_bm();
 	}
 }
 
@@ -556,6 +558,7 @@ void crimson_tng_impl::start_bm() {
 		_bm_thread_should_exit = false;
 		_bm_thread = std::thread( bm_thread_fn, this );
 
+		_time_diff_converged = false;
 		for(
 			time_spec_t time_then = uhd::time_spec_t::get_system_time(),
 				time_now = time_then

--- a/host/lib/usrp/crimson_tng/io_impl.cpp
+++ b/host/lib/usrp/crimson_tng/io_impl.cpp
@@ -161,6 +161,9 @@ public:
         uhd::time_spec_t sob_time;
         uhd::time_spec_t now = get_time_now();
 
+        if ( ! metadata.start_of_burst ) {
+            metadata.has_time_spec = false;
+        }
         if ( _first_call_to_send ) {
             if ( ! metadata.start_of_burst ) {
                 #ifdef UHD_TXRX_DEBUG_PRINTS
@@ -186,7 +189,7 @@ public:
                 #endif
             }
             #ifdef UHD_TXRX_DEBUG_PRINTS
-            UHD_MSG( status ) << get_time_now() << ": Setting start of burst @ " << metadata.time_spec << std::endl;
+            UHD_MSG( status ) << get_time_now() << ": Setting start of burst @ " << metadata.time_spec << " or " << metadata.time_spec.to_ticks( 162500000 ) << std::endl;
             #endif
             for( auto & ep: _eprops ) {
 				ep.flow_control->set_start_of_burst_time( metadata.time_spec );
@@ -196,9 +199,14 @@ public:
         _first_call_to_send = false;
         r = send_packet_handler::send(buffs, nsamps_per_buff, metadata, timeout);
 
-        #ifdef UHD_TXRX_DEBUG_PRINTS
         now = get_time_now();
-        if ( now < sob_time ) {
+
+        #ifdef UHD_TXRX_DEBUG_PRINTS
+        if (
+            true
+            && r > 0
+	    && now < sob_time + 0.5
+        ) {
             UHD_MSG( status ) << now << ": Sent " << r << " samples" << std::endl;
         }
         #endif

--- a/host/lib/usrp/crimson_tng/io_impl.cpp
+++ b/host/lib/usrp/crimson_tng/io_impl.cpp
@@ -158,6 +158,7 @@ public:
 
         uhd::tx_metadata_t metadata = metadata_;
 
+        uhd::time_spec_t sob_time;
         uhd::time_spec_t now = get_time_now();
 
         if ( _first_call_to_send ) {
@@ -190,12 +191,16 @@ public:
             for( auto & ep: _eprops ) {
 				ep.flow_control->set_start_of_burst_time( metadata.time_spec );
             }
+            sob_time = metadata.time_spec;
         }
         _first_call_to_send = false;
         r = send_packet_handler::send(buffs, nsamps_per_buff, metadata, timeout);
 
         #ifdef UHD_TXRX_DEBUG_PRINTS
-        UHD_MSG( status ) << get_time_now() << ": Sent " << r << " samples" << std::endl;
+        now = get_time_now();
+        if ( now < sob_time ) {
+            UHD_MSG( status ) << now << ": Sent " << r << " samples" << std::endl;
+        }
         #endif
 
         if ( metadata.end_of_burst && ( 0 == nsamps_per_buff || nsamps_per_buff == r ) ) {

--- a/host/lib/usrp/crimson_tng/io_impl.cpp
+++ b/host/lib/usrp/crimson_tng/io_impl.cpp
@@ -185,7 +185,7 @@ public:
                 #endif
             }
             #ifdef UHD_TXRX_DEBUG_PRINTS
-            UHD_MSG( status ) << get_time_now() << ": Sending start of burst @ " << metadata.time_spec << std::endl;
+            UHD_MSG( status ) << get_time_now() << ": Setting start of burst @ " << metadata.time_spec << std::endl;
             #endif
             for( auto & ep: _eprops ) {
 				ep.flow_control->set_start_of_burst_time( metadata.time_spec );
@@ -195,7 +195,7 @@ public:
         r = send_packet_handler::send(buffs, nsamps_per_buff, metadata, timeout);
 
         #ifdef UHD_TXRX_DEBUG_PRINTS
-        //UHD_MSG( status ) << get_time_now() << ": Sent " << r << " samples" << std::endl;
+        UHD_MSG( status ) << get_time_now() << ": Sent " << r << " samples" << std::endl;
         #endif
 
         if ( metadata.end_of_burst && ( 0 == nsamps_per_buff || nsamps_per_buff == r ) ) {

--- a/host/lib/usrp/crimson_tng/io_impl.cpp
+++ b/host/lib/usrp/crimson_tng/io_impl.cpp
@@ -120,6 +120,7 @@ public:
 		sph::send_packet_streamer( max_num_samps ),
 		_first_call_to_send( true ),
 		_max_num_samps( max_num_samps ),
+		_actual_num_samps( max_num_samps ),
 		_samp_rate( 1.0 ),
 		_blessbless( false ) // icelandic (viking) for bye
 	{
@@ -207,7 +208,7 @@ public:
 
         // XXX: @CF: 20180320: Our strategy of predictive flow control is not 100% compatible with
         // the UHD API. As such, we need to bury this variable in order to pass it to check_fc_condition.
-        _actual_num_samps = nsamps_per_buff % _max_num_samps;
+        _actual_num_samps = nsamps_per_buff > _max_num_samps ? _max_num_samps : nsamps_per_buff;
         r = send_packet_handler::send(buffs, nsamps_per_buff, metadata, timeout);
 
         now = get_time_now();

--- a/host/lib/usrp/crimson_tng/io_impl.cpp
+++ b/host/lib/usrp/crimson_tng/io_impl.cpp
@@ -623,9 +623,13 @@ rx_streamer::sptr crimson_tng_impl::get_rx_stream(const uhd::stream_args_t &args
             if (chan < num_chan_so_far){
                 const size_t dsp = chan + _mbc[mb].rx_chan_occ - num_chan_so_far;
                 std::string scmd_pre( "rx_" + std::string( 1, 'a' + chan ) + "/stream" );
-                stream_cmd_t scmd( stream_cmd_t::STREAM_MODE_STOP_CONTINUOUS );
-                scmd.stream_now = true;
-                set_stream_cmd( scmd_pre, scmd );
+                /* XXX: @CF: 20180321: This causes QA to issue 'd' and then 'o' and fail.
+                 * Shouldn't _really_ need it here, but it was originally here to shut down
+                 * the channel in case it was not previously shut down
+                 */
+                //stream_cmd_t scmd( stream_cmd_t::STREAM_MODE_STOP_CONTINUOUS );
+                //scmd.stream_now = true;
+                //set_stream_cmd( scmd_pre, scmd );
                 my_streamer->set_xport_chan_get_buff(chan_i, boost::bind(
                     &zero_copy_if::get_recv_buff, _mbc[mb].rx_dsp_xports[dsp], _1
                 ), true /*flush*/);

--- a/host/lib/usrp/crimson_tng/pidc.hpp
+++ b/host/lib/usrp/crimson_tng/pidc.hpp
@@ -44,6 +44,7 @@ namespace uhd {
 			// initialize the control variable to be equal to the set point, so error is initially zero
 			cv( 0.0 ),
 			sp( sp ),
+			offset( 0.0 ),
 			last_time( 0 ),
 			last_status_time( 0 ),
 			converged( false ),


### PR DESCRIPTION

Fix flow control with new TX api  …
We adopted upstream's sph::send_packet_streamer API for TX. Unfortunately,
upstream's flow control models are all reactive rather than predictive or
predictive + reactive.

Our flow control model is predictive + reactive. As such, we rely on
passing in a relatively accurate figure for the number of samples sent
in each buffer within get_send_buff() / check_fc_condition().

The current, potentially long-term, solution is to just bury that figure
in a variable called _actual_num_samps within the
crimson_tng_send_packet_streamer class.