### PR TITLE
Fixups required for rx_samples_to_file_crimson demo (RX phase alignment)

### DIFF
--- a/host/lib/transport/udp_stream_zero_copy.cpp
+++ b/host/lib/transport/udp_stream_zero_copy.cpp
@@ -185,7 +185,7 @@ public:
 		_local_addr( local_addr ), _local_port( local_port ),
 		_remote_addr( remote_addr ), _remote_port( remote_port ), _remote_sockaddr( to_sockaddr_in( remote_addr, remote_port ) )
     {
-        UHD_LOGGER_TRACE( "UDP" ) << boost::format("Creating udp transport for %s %s") % local_addr % local_port << std::endl;
+        //UHD_LOGGER_TRACE( "UDP" ) << boost::format("Creating udp transport for %s %s") % local_addr % local_port << std::endl;
 
         #ifdef CHECK_REG_SEND_THRESH
         check_registry_for_fast_send_threshold(this->get_send_frame_size());

--- a/host/lib/usrp/crimson_tng/io_impl.cpp
+++ b/host/lib/usrp/crimson_tng/io_impl.cpp
@@ -665,6 +665,7 @@ rx_streamer::sptr crimson_tng_impl::get_rx_stream(const uhd::stream_args_t &args
                 const fs_path rx_link_path  = mb_path / "rx_link" / ch;
                 const fs_path rx_dsp_path   = mb_path / "rx_dsps" / ch;
 
+                _tree->access<std::string>(rx_link_path / "stream").set("0");
                 // vita enable
                 _tree->access<std::string>(rx_link_path / "vita_en").set("1");
 


### PR DESCRIPTION
This is a combination of a few changes.

There were two changes that were previously done but lost in rebasing to ettus/master

* disable rx stream before enabling it
* power on and enable rx stream before sending out any stream command that is not STOP_CONTINUOUS

The first one has no real side effects and just signals to the FPGA that it should empty the RX buffer and perform other reset operations.

The second one is part of a fairly nasty set of workarounds for both TX and RX that have to do with broken reference counting in shared pointers. I believe this is a UHD-wide bug and not specific to crimson_tng, but I'm not certain. Other USRP targets perform similar workarounds - e.g. sending "mini-eob" to signal the streamer to tear itself down.

The last change just allows some of the set_tx and set_rx methods in multi_crimson_tng to recognize ALL_CHANS. Note, that we are breaking spec with multi_usrp which specifies that the default channel to take effect with is channel zero. However, doing so seems to be mostly desireable behaviour.