### PR TITLE
Combine multi_crimson_tng.cpp into multi_usrp.cpp

### DIFF
--- a/host/lib/usrp/CMakeLists.txt
+++ b/host/lib/usrp/CMakeLists.txt
@@ -17,7 +17,6 @@ LIBUHD_APPEND_SOURCES(
     ${CMAKE_CURRENT_SOURCE_DIR}/dboard_iface.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/dboard_manager.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/gps_ctrl.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/multi_crimson_tng.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/multi_usrp.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/subdev_spec.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/fe_connection.cpp

--- a/host/lib/usrp/crimson_tng/crimson_tng_fw_common.h
+++ b/host/lib/usrp/crimson_tng/crimson_tng_fw_common.h
@@ -25,9 +25,6 @@
  * This header is shared by the firmware and host code.
  * Therefore, this header may only contain valid C code.
  */
-#ifdef __cplusplus
-extern "C" {
-#endif
 
 #define CMD_SUCCESS 	'0'
 #define CMD_ERROR	'1'
@@ -119,9 +116,5 @@ extern "C" {
 				( CRIMSON_TNG_VITA_TLR_IND    << 8) |\
 				( CRIMSON_TNG_VITA_TLR_E      << 7) |\
 				( CRIMSON_TNG_VITA_TLR_PCKCNT << 0) )
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif /* INCLUDED_CRIMSON_TNG_FW_COMMON_H */

--- a/host/lib/usrp/crimson_tng/crimson_tng_impl.cpp
+++ b/host/lib/usrp/crimson_tng/crimson_tng_impl.cpp
@@ -225,8 +225,11 @@ void crimson_tng_impl::set_stream_cmd( const std::string pre, const stream_cmd_t
 // wrapper for type <time_spec_t> through the ASCII Crimson interface
 // we should get back time in the form "12345.6789" from Crimson, where it is seconds elapsed relative to Crimson bootup.
 time_spec_t crimson_tng_impl::get_time_spec(std::string req) {
-	if ( "time/clk/cur_time" == req ) {
+	if ( false ) {
+	} else if ( "time/clk/cur_time" == req ) {
 		return get_time_now();
+	} else if ( "time/clk/pps" == req ) {
+		return uhd::time_spec_t( get_time_now().get_full_secs() );
 	} else {
 		double fracpart, intpart;
 		fracpart = modf(get_double(req), &intpart);

--- a/host/lib/usrp/crimson_tng/crimson_tng_impl.cpp
+++ b/host/lib/usrp/crimson_tng/crimson_tng_impl.cpp
@@ -879,14 +879,11 @@ crimson_tng_impl::crimson_tng_impl(const device_addr_t &_device_addr)
 		static const std::vector<std::string> sensor_options = boost::assign::list_of("lo_locked");
 		_tree->create<std::vector<std::string> >(rx_fe_path / "sensors").set(sensor_options);
 
-		// Actual frequency values
-		TREE_CREATE_RW(rx_path / chan / "freq" / "value", "rx_"+lc_num+"/rf/freq/val", double, double);
-
 		// Power status
 		TREE_CREATE_RW(rx_path / dspno / "pwr", "rx_"+lc_num+"/pwr", std::string, string);
 
 		// Channel Stream Status
-		TREE_CREATE_RW(rx_link_path / "stream", "rx_"+lc_num+"/stream", std::string, string);
+		TREE_CREATE_RW(rx_path / dspno / "stream", "rx_"+lc_num+"/stream", std::string, string);
 
 		// Codecs, phony properties for Crimson
 		TREE_CREATE_RW(rx_codec_path / "gains", "rx_"+lc_num+"/dsp/gain", int, int);
@@ -899,9 +896,6 @@ crimson_tng_impl::crimson_tng_impl(const device_addr_t &_device_addr)
 		TREE_CREATE_ST(rx_fe_path / "bandwidth" / "value", double, CRIMSON_TNG_MASTER_CLOCK_RATE / 2.0 );
 		TREE_CREATE_ST(rx_fe_path / "bandwidth" / "range", meta_range_t, meta_range_t( CRIMSON_TNG_MASTER_CLOCK_RATE / 2.0, CRIMSON_TNG_MASTER_CLOCK_RATE / 2.0 ) );
 
-		TREE_CREATE_ST(rx_fe_path / "gains" / "LMH+PE" / "range", meta_range_t,
-			meta_range_t(CRIMSON_TNG_RF_RX_GAIN_RANGE_START, CRIMSON_TNG_RF_RX_GAIN_RANGE_STOP, CRIMSON_TNG_RF_RX_GAIN_RANGE_STEP));
-
 		TREE_CREATE_ST(rx_fe_path / "freq", meta_range_t,
 			meta_range_t(CRIMSON_TNG_FREQ_RANGE_START, CRIMSON_TNG_FREQ_RANGE_STOP, CRIMSON_TNG_FREQ_RANGE_STEP));
 
@@ -911,7 +905,8 @@ crimson_tng_impl::crimson_tng_impl(const device_addr_t &_device_addr)
 
 		TREE_CREATE_RW(rx_fe_path / "connection",  "rx_"+lc_num+"/link/iface", std::string, string);
 
-		TREE_CREATE_ST(rx_fe_path / "use_lo_offset", bool, false);
+		TREE_CREATE_ST(rx_fe_path / "use_lo_offset", bool, true );
+		TREE_CREATE_ST(rx_fe_path / "lo_offset" / "value", double, 15e6 );
 
 		TREE_CREATE_ST(rx_fe_path / "freq" / "range", meta_range_t,
 			meta_range_t(CRIMSON_TNG_FREQ_RANGE_START, CRIMSON_TNG_FREQ_RANGE_STOP, CRIMSON_TNG_FREQ_RANGE_STEP));
@@ -919,6 +914,7 @@ crimson_tng_impl::crimson_tng_impl(const device_addr_t &_device_addr)
 			meta_range_t(CRIMSON_TNG_RF_RX_GAIN_RANGE_START, CRIMSON_TNG_RF_RX_GAIN_RANGE_STOP, CRIMSON_TNG_RF_RX_GAIN_RANGE_STEP));
 
 		TREE_CREATE_RW(rx_fe_path / "freq"  / "value", "rx_"+lc_num+"/rf/freq/val" , double, double);
+		TREE_CREATE_ST(rx_fe_path / "gains", std::string, "gain" );
 		TREE_CREATE_RW(rx_fe_path / "gain"  / "value", "rx_"+lc_num+"/rf/gain/val" , double, double);
 		TREE_CREATE_RW(rx_fe_path / "atten" / "value", "rx_"+lc_num+"/rf/atten/val", double, double);
 
@@ -1035,9 +1031,6 @@ crimson_tng_impl::crimson_tng_impl(const device_addr_t &_device_addr)
 		TREE_CREATE_ST(tx_fe_path / "bandwidth" / "value", double, CRIMSON_TNG_MASTER_CLOCK_RATE / 2.0 );
 		TREE_CREATE_ST(tx_fe_path / "bandwidth" / "range", meta_range_t, meta_range_t( CRIMSON_TNG_MASTER_CLOCK_RATE / 2.0, CRIMSON_TNG_MASTER_CLOCK_RATE / 2.0 ) );
 
-		TREE_CREATE_ST(tx_fe_path / "gains" / "PE" / "range",	meta_range_t,
-			meta_range_t(CRIMSON_TNG_RF_TX_GAIN_RANGE_START, CRIMSON_TNG_RF_TX_GAIN_RANGE_STOP, CRIMSON_TNG_RF_TX_GAIN_RANGE_STEP));
-
 		TREE_CREATE_ST(tx_fe_path / "freq", meta_range_t,
 			meta_range_t(CRIMSON_TNG_FREQ_RANGE_START, CRIMSON_TNG_FREQ_RANGE_STOP, CRIMSON_TNG_FREQ_RANGE_STEP));
 
@@ -1055,6 +1048,7 @@ crimson_tng_impl::crimson_tng_impl(const device_addr_t &_device_addr)
 			meta_range_t(CRIMSON_TNG_RF_TX_GAIN_RANGE_START, CRIMSON_TNG_RF_TX_GAIN_RANGE_STOP, CRIMSON_TNG_RF_TX_GAIN_RANGE_STEP));
 
 		TREE_CREATE_RW(tx_fe_path / "freq"  / "value", "tx_"+lc_num+"/rf/freq/val" , double, double);
+		TREE_CREATE_ST(tx_fe_path / "gains", std::string, "gain" );
 		TREE_CREATE_RW(tx_fe_path / "gain"  / "value", "tx_"+lc_num+"/rf/gain/val" , double, double);
 
 		// RF band
@@ -1218,8 +1212,7 @@ crimson_tng_impl::crimson_tng_impl(const device_addr_t &_device_addr)
 
 crimson_tng_impl::~crimson_tng_impl(void)
 {
-	std::cout << __func__ << "(): " << std::endl;
-	stop_bm();
+       stop_bm();
 }
 
 bool crimson_tng_impl::is_bm_thread_needed() {

--- a/host/lib/usrp/crimson_tng/crimson_tng_impl.cpp
+++ b/host/lib/usrp/crimson_tng/crimson_tng_impl.cpp
@@ -614,19 +614,10 @@ void crimson_tng_impl::bm_thread_fn( crimson_tng_impl *dev ) {
 	) {
 
 		dt = then - now;
-		if ( dt > 1e-3 ) {
-			dt -= 30e-6;
+		if ( dt > 0.0 ) {
 			req.tv_sec = dt.get_full_secs();
 			req.tv_nsec = dt.get_frac_secs() * 1e9;
 			nanosleep( &req, &rem );
-		}
-		for(
-			now = uhd::get_system_time();
-			now < then;
-			now = uhd::get_system_time()
-		) {
-			// nop
-			asm __volatile__( "" );
 		}
 
 		time_diff = dev->_time_diff_pidc.get_control_variable();

--- a/host/lib/usrp/crimson_tng/crimson_tng_impl.cpp
+++ b/host/lib/usrp/crimson_tng/crimson_tng_impl.cpp
@@ -218,34 +218,8 @@ void crimson_tng_impl::set_stream_cmd( const std::string pre, const stream_cmd_t
 
 	uhd::usrp::rx_stream_cmd rx_stream_cmd;
 
-	// XXX: @CF: 20180214: While I would have preferred to *not* put this in here, it seems to be the safest place.
-	// If GNURadio is using libuhd "/stream" is not set to 0 if this code is not here. Possibly improper reference counting.
-	if ( stream_cmd_t::STREAM_MODE_STOP_CONTINUOUS != stream_cmd.stream_mode ) {
-		const std::string stream_path = "/mboards/0/rx_link/Channel_" + std::string( 1, (char) 'A' + ch ) + "/stream";
-		const std::string pwr_path = "/mboards/0/rx/Channel_" + std::string( 1, (char) 'A' + ch ) + "/pwr";
-		_tree->access<std::string>( stream_path ).set( "1" );
-		_tree->access<std::string>( pwr_path ).set( "1" );
-	}
-
 	make_rx_stream_cmd_packet( stream_cmd, now, ch, rx_stream_cmd );
 	send_rx_stream_cmd_req( rx_stream_cmd );
-
-	// XXX: @CF: 20180214: While I would have preferred to *not* put this in here, it seems to be the safest place.
-	// If GNURadio is using libuhd "/stream" is not set to 0 if this code is not here. Possibly improper reference counting.
-	if (
-		true
-		&& stream_cmd_t::STREAM_MODE_STOP_CONTINUOUS == stream_cmd.stream_mode
-		&& (
-			false
-			|| stream_cmd.stream_now
-			|| now >= stream_cmd.time_spec
-		)
-	) {
-		const std::string stream_path = "/mboards/0/rx_link/Channel_" + std::string( 1, (char) 'A' + ch ) + "/stream";
-		const std::string pwr_path = "/mboards/0/rx/Channel_" + std::string( 1, (char) 'A' + ch ) + "/pwr";
-		_tree->access<std::string>( stream_path ).set( "0" );
-		_tree->access<std::string>( pwr_path ).set( "0" );
-	}
 }
 
 // wrapper for type <time_spec_t> through the ASCII Crimson interface
@@ -690,7 +664,7 @@ static device::sptr crimson_tng_make(const device_addr_t &device_addr)
 // all the registered devices' find and make functions.
 UHD_STATIC_BLOCK(register_crimson_tng_device)
 {
-    device::register_device(&crimson_tng_find, &crimson_tng_make, device::CRIMSON_TNG);
+    device::register_device(&crimson_tng_find, &crimson_tng_make, device::USRP);
 }
 
 /***********************************************************************
@@ -808,6 +782,17 @@ crimson_tng_impl::crimson_tng_impl(const device_addr_t &_device_addr)
 
     TREE_CREATE_ST("/name", std::string, "Crimson_TNG Device");
 
+    ////////////////////////////////////////////////////////////////////
+    // create frontend mapping
+    ////////////////////////////////////////////////////////////////////
+    static const std::vector<size_t> default_map { 0, 1, 2, 3 };
+    _tree->create<std::vector<size_t> >(mb_path / "rx_chan_dsp_mapping").set(default_map);
+    _tree->create<std::vector<size_t> >(mb_path / "tx_chan_dsp_mapping").set(default_map);
+    _tree->create<subdev_spec_t>(mb_path / "rx_subdev_spec")
+        .add_coerced_subscriber(boost::bind(&crimson_tng_impl::update_rx_subdev_spec, this, mb, _1));
+    _tree->create<subdev_spec_t>(mb_path / "tx_subdev_spec")
+        .add_coerced_subscriber(boost::bind(&crimson_tng_impl::update_tx_subdev_spec, this, mb, _1));
+
     TREE_CREATE_ST(mb_path / "vendor", std::string, "Per Vices");
     TREE_CREATE_ST(mb_path / "name",   std::string, "FPGA Board");
     TREE_CREATE_RW(mb_path / "id",         "fpga/about/id",     std::string, string);
@@ -877,16 +862,16 @@ crimson_tng_impl::crimson_tng_impl(const device_addr_t &_device_addr)
     // TREE_CREATE_ST(mb_path / "sensors" / "ref_locked", sensor_value_t, sensor_value_t("NA", "0", "NA"));
 
     // loop for all RX chains
-    for( size_t chain = 0; chain < CRIMSON_TNG_RX_CHANNELS; chain++ ) {
-		std::string lc_num  = boost::lexical_cast<std::string>((char)(chain + 'a'));
-		std::string num     = boost::lexical_cast<std::string>((char)(chain + 'A'));
+    for( size_t dspno = 0; dspno < CRIMSON_TNG_RX_CHANNELS; dspno++ ) {
+		std::string lc_num  = boost::lexical_cast<std::string>((char)(dspno + 'a'));
+		std::string num     = boost::lexical_cast<std::string>((char)(dspno + 'A'));
 		std::string chan    = "Channel_" + num;
 
 		const fs_path rx_codec_path = mb_path / "rx_codecs" / num;
 		const fs_path rx_fe_path    = mb_path / "dboards" / num / "rx_frontends" / chan;
 		const fs_path db_path       = mb_path / "dboards" / num;
-		const fs_path rx_dsp_path   = mb_path / "rx_dsps" / chan;
-		const fs_path rx_link_path  = mb_path / "rx_link" / chan;
+		const fs_path rx_dsp_path   = mb_path / "rx_dsps" / dspno;
+		const fs_path rx_link_path  = mb_path / "rx_link" / dspno;
 
 		static const std::vector<std::string> antenna_options = boost::assign::list_of("SMA")("None");
 		_tree->create<std::vector<std::string> >(rx_fe_path / "antenna" / "options").set(antenna_options);
@@ -898,7 +883,7 @@ crimson_tng_impl::crimson_tng_impl(const device_addr_t &_device_addr)
 		TREE_CREATE_RW(rx_path / chan / "freq" / "value", "rx_"+lc_num+"/rf/freq/val", double, double);
 
 		// Power status
-		TREE_CREATE_RW(rx_path / chan / "pwr", "rx_"+lc_num+"/pwr", std::string, string);
+		TREE_CREATE_RW(rx_path / dspno / "pwr", "rx_"+lc_num+"/pwr", std::string, string);
 
 		// Channel Stream Status
 		TREE_CREATE_RW(rx_link_path / "stream", "rx_"+lc_num+"/stream", std::string, string);
@@ -909,6 +894,10 @@ crimson_tng_impl::crimson_tng_impl(const device_addr_t &_device_addr)
 
 		// Daughter Boards' Frontend Settings
 		TREE_CREATE_ST(rx_fe_path / "name",   std::string, "RX Board");
+
+	    // RX bandwidth
+		TREE_CREATE_ST(rx_fe_path / "bandwidth" / "value", double, CRIMSON_TNG_MASTER_CLOCK_RATE / 2.0 );
+		TREE_CREATE_ST(rx_fe_path / "bandwidth" / "range", meta_range_t, meta_range_t( CRIMSON_TNG_MASTER_CLOCK_RATE / 2.0, CRIMSON_TNG_MASTER_CLOCK_RATE / 2.0 ) );
 
 		TREE_CREATE_ST(rx_fe_path / "gains" / "LMH+PE" / "range", meta_range_t,
 			meta_range_t(CRIMSON_TNG_RF_RX_GAIN_RANGE_START, CRIMSON_TNG_RF_RX_GAIN_RANGE_STOP, CRIMSON_TNG_RF_RX_GAIN_RANGE_STEP));
@@ -944,7 +933,7 @@ crimson_tng_impl::crimson_tng_impl(const device_addr_t &_device_addr)
 		TREE_CREATE_ST(db_path / "gdb_eeprom", dboard_eeprom_t, dboard_eeprom_t());
 
 		// DSPs
-		switch( chain + 'A' ) {
+		switch( dspno + 'A' ) {
 		case 'A':
 		case 'B':
 			TREE_CREATE_ST(rx_dsp_path / "rate" / "range", meta_range_t,
@@ -967,7 +956,7 @@ crimson_tng_impl::crimson_tng_impl(const device_addr_t &_device_addr)
 
 		_tree->create<double> (rx_dsp_path / "rate" / "value")
 			.set( get_double ("rx_"+lc_num+"/dsp/rate"))
-			.add_desired_subscriber(boost::bind(&crimson_tng_impl::update_rx_samp_rate, this, mb, (size_t) chain, _1))
+			.add_desired_subscriber(boost::bind(&crimson_tng_impl::update_rx_samp_rate, this, mb, (size_t) dspno, _1))
 			.set_publisher(boost::bind(&crimson_tng_impl::get_double, this, ("rx_"+lc_num+"/dsp/rate")    ));
 
 		TREE_CREATE_RW(rx_dsp_path / "freq" / "value", "rx_"+lc_num+"/dsp/nco_adj", double, double);
@@ -1010,19 +999,18 @@ crimson_tng_impl::crimson_tng_impl(const device_addr_t &_device_addr)
 			)
 		);
     }
-    _mbc[ mb ].rx_chan_occ = 4;
 
     // loop for all TX chains
-    for( int chain = 0; chain < CRIMSON_TNG_TX_CHANNELS; chain++ ) {
-		std::string lc_num  = boost::lexical_cast<std::string>((char)(chain + 'a'));
-		std::string num     = boost::lexical_cast<std::string>((char)(chain + 'A'));
+    for( int dspno = 0; dspno < CRIMSON_TNG_TX_CHANNELS; dspno++ ) {
+		std::string lc_num  = boost::lexical_cast<std::string>((char)(dspno + 'a'));
+		std::string num     = boost::lexical_cast<std::string>((char)(dspno + 'A'));
 		std::string chan    = "Channel_" + num;
 
 		const fs_path tx_codec_path = mb_path / "tx_codecs" / num;
 		const fs_path tx_fe_path    = mb_path / "dboards" / num / "tx_frontends" / chan;
 		const fs_path db_path       = mb_path / "dboards" / num;
-		const fs_path tx_dsp_path   = mb_path / "tx_dsps" / chan;
-		const fs_path tx_link_path  = mb_path / "tx_link" / chan;
+		const fs_path tx_dsp_path   = mb_path / "tx_dsps" / dspno;
+		const fs_path tx_link_path  = mb_path / "tx_link" / dspno;
 
 		static const std::vector<std::string> antenna_options = boost::assign::list_of("SMA")("None");
 		_tree->create<std::vector<std::string> >(tx_fe_path / "antenna" / "options").set(antenna_options);
@@ -1034,7 +1022,7 @@ crimson_tng_impl::crimson_tng_impl(const device_addr_t &_device_addr)
 		TREE_CREATE_RW(tx_path / chan / "freq" / "value", "tx_"+lc_num+"/rf/freq/val", double, double);
 
 		// Power status
-		TREE_CREATE_RW(tx_path / chan / "pwr", "tx_"+lc_num+"/pwr", std::string, string);
+		TREE_CREATE_RW(tx_path / dspno / "pwr", "tx_"+lc_num+"/pwr", std::string, string);
 
 		// Codecs, phony properties for Crimson
 		TREE_CREATE_RW(tx_codec_path / "gains", "tx_"+lc_num+"/dsp/gain", int, int);
@@ -1042,6 +1030,10 @@ crimson_tng_impl::crimson_tng_impl(const device_addr_t &_device_addr)
 
 		// Daughter Boards' Frontend Settings
 		TREE_CREATE_ST(tx_fe_path / "name",   std::string, "TX Board");
+
+	    // TX bandwidth
+		TREE_CREATE_ST(tx_fe_path / "bandwidth" / "value", double, CRIMSON_TNG_MASTER_CLOCK_RATE / 2.0 );
+		TREE_CREATE_ST(tx_fe_path / "bandwidth" / "range", meta_range_t, meta_range_t( CRIMSON_TNG_MASTER_CLOCK_RATE / 2.0, CRIMSON_TNG_MASTER_CLOCK_RATE / 2.0 ) );
 
 		TREE_CREATE_ST(tx_fe_path / "gains" / "PE" / "range",	meta_range_t,
 			meta_range_t(CRIMSON_TNG_RF_TX_GAIN_RANGE_START, CRIMSON_TNG_RF_TX_GAIN_RANGE_STOP, CRIMSON_TNG_RF_TX_GAIN_RANGE_STEP));
@@ -1072,7 +1064,7 @@ crimson_tng_impl::crimson_tng_impl(const device_addr_t &_device_addr)
 		TREE_CREATE_ST(db_path / "tx_eeprom",  dboard_eeprom_t, dboard_eeprom_t());
 
 		// DSPs
-		switch( chain + 'A' ) {
+		switch( dspno + 'A' ) {
 		case 'A':
 		case 'B':
 			TREE_CREATE_ST(tx_dsp_path / "rate" / "range", meta_range_t,
@@ -1095,7 +1087,7 @@ crimson_tng_impl::crimson_tng_impl(const device_addr_t &_device_addr)
 
 		_tree->create<double> (tx_dsp_path / "rate" / "value")
 			.set( get_double ("tx_"+lc_num+"/dsp/rate"))
-			.add_desired_subscriber(boost::bind(&crimson_tng_impl::update_tx_samp_rate, this, mb, (size_t) chain, _1))
+			.add_desired_subscriber(boost::bind(&crimson_tng_impl::update_tx_samp_rate, this, mb, (size_t) dspno, _1))
 			.set_publisher(boost::bind(&crimson_tng_impl::get_double, this, ("tx_"+lc_num+"/dsp/rate")    ));
 
 		TREE_CREATE_RW(tx_dsp_path / "bw" / "value",   "tx_"+lc_num+"/dsp/rate",    double, double);
@@ -1128,7 +1120,7 @@ crimson_tng_impl::crimson_tng_impl(const device_addr_t &_device_addr)
 		std::string ip_addr;
 		uint16_t udp_port;
 		std::string sfp;
-		get_tx_endpoint( _tree, chain, ip_addr, udp_port, sfp );
+		get_tx_endpoint( _tree, dspno, ip_addr, udp_port, sfp );
 
 		_mbc[mb].tx_dsp_xports.push_back(
 			udp_zero_copy::make(
@@ -1147,7 +1139,6 @@ crimson_tng_impl::crimson_tng_impl(const device_addr_t &_device_addr)
 			)
 		);
     }
-    _mbc[ mb ].tx_chan_occ = 4;
 
 	const fs_path cm_path  = mb_path / "cm";
 
@@ -1161,6 +1152,33 @@ crimson_tng_impl::crimson_tng_impl(const device_addr_t &_device_addr)
 	TREE_CREATE_RW(cm_path / "trx/nco_adj", "cm/trx/nco_adj", double, double);
 
 	this->io_init();
+
+    //do some post-init tasks
+    this->update_rates();
+    for(const std::string &mb:  _mbc.keys()){
+        fs_path root = "/mboards/" + mb;
+
+        //reset cordic rates and their properties to zero
+//        for(const std::string &name:  _tree->list(root / "rx_dsps")){
+//            _tree->access<double>(root / "rx_dsps" / name / "freq" / "value").set(0.0);
+//        }
+//        for(const std::string &name:  _tree->list(root / "tx_dsps")){
+//            _tree->access<double>(root / "tx_dsps" / name / "freq" / "value").set(0.0);
+//        }
+
+		_tree->access<subdev_spec_t>(root / "rx_subdev_spec").set(subdev_spec_t( "A:Channel_A B:Channel_B C:Channel_C D:Channel_D" ));
+		_tree->access<subdev_spec_t>(root / "tx_subdev_spec").set(subdev_spec_t( "A:Channel_A B:Channel_B C:Channel_C D:Channel_D" ));
+        _tree->access<std::string>(root / "clock_source/value").set("internal");
+        _tree->access<std::string>(root / "time_source/value").set("none");
+
+        //GPS installed: use external ref, time, and init time spec
+//        if (_mbc[mb].gps and _mbc[mb].gps->gps_detected()){
+//            _mbc[mb].time64->enable_gpsdo();
+//            UHD_LOGGER_INFO("USRP2") << "Setting references to the internal GPSDO" ;
+//            _tree->access<std::string>(root / "time_source/value").set("gpsdo");
+//            _tree->access<std::string>(root / "clock_source/value").set("gpsdo");
+//        }
+    }
 
 	// it does not currently matter whether we use the sfpa or sfpb port atm, they both access the same fpga hardware block
 	int sfpa_port = _tree->access<int>( mb_path / "fpga/board/flow_control/sfpa_port" ).get();
@@ -1200,6 +1218,7 @@ crimson_tng_impl::crimson_tng_impl(const device_addr_t &_device_addr)
 
 crimson_tng_impl::~crimson_tng_impl(void)
 {
+	std::cout << __func__ << "(): " << std::endl;
 	stop_bm();
 }
 
@@ -1244,7 +1263,7 @@ void crimson_tng_impl::get_tx_endpoint( uhd::property_tree::sptr tree, const siz
 	const fs_path mb_path   = "/mboards/0";
 	const fs_path prop_path = mb_path / "tx_link";
 
-	const std::string udp_port_str = tree->access<std::string>(prop_path / "Channel_" + chan_str / "port").get();
+	const std::string udp_port_str = tree->access<std::string>(prop_path / std::to_string( chan ) / "port").get();
 
 	std::stringstream udp_port_ss( udp_port_str );
 	udp_port_ss >> udp_port;

--- a/host/lib/usrp/crimson_tng/crimson_tng_impl.hpp
+++ b/host/lib/usrp/crimson_tng/crimson_tng_impl.hpp
@@ -195,6 +195,7 @@ private:
         std::vector<uhd::transport::zero_copy_if::sptr> rx_dsp_xports;
         std::vector<uhd::transport::zero_copy_if::sptr> tx_dsp_xports;
         std::vector<uhd::transport::udp_simple::sptr> fifo_ctrl_xports;
+        // radio control core sort of like magnesium (maybe plutonium? only if it's organic)
         size_t rx_chan_occ, tx_chan_occ;
         mb_container_type(void): rx_chan_occ(0), tx_chan_occ(0){}
     };

--- a/host/lib/usrp/crimson_tng/flow_control_nonlinear.hpp
+++ b/host/lib/usrp/crimson_tng/flow_control_nonlinear.hpp
@@ -111,7 +111,13 @@ public:
 
 		if ( BOOST_UNLIKELY( unlocked_start_of_burst_pending( now ) ) ) {
 
+			dt = sob_time - now;
+			if ( dt > 0.2 ) {
+				return dt.get_real_secs() - 0.2;
+			}
+
 			bl = unlocked_get_buffer_level( now );
+
 			if ( nominal_buffer_level > bl ) {
 				dt = 0.0;
 			} else {

--- a/host/lib/usrp/crimson_tng/flow_control_nonlinear.hpp
+++ b/host/lib/usrp/crimson_tng/flow_control_nonlinear.hpp
@@ -112,10 +112,6 @@ public:
 		if ( BOOST_UNLIKELY( unlocked_start_of_burst_pending( now ) ) ) {
 
 			dt = sob_time - now;
-			if ( dt > 0.2 ) {
-				return dt.get_real_secs() - 0.2;
-			}
-
 			bl = unlocked_get_buffer_level( now );
 
 			if ( nominal_buffer_level > bl ) {

--- a/host/lib/usrp/crimson_tng/io_impl.cpp
+++ b/host/lib/usrp/crimson_tng/io_impl.cpp
@@ -73,6 +73,7 @@ public:
     }
 
 	virtual ~crimson_tng_recv_packet_streamer() {
+		std::cout << __func__ << "(): " << std::endl;
 		for( auto & ep: _eprops ) {
 			if ( ep.on_fini ) {
 				ep.on_fini();

--- a/host/lib/usrp/crimson_tng/io_impl.cpp
+++ b/host/lib/usrp/crimson_tng/io_impl.cpp
@@ -674,6 +674,7 @@ rx_streamer::sptr crimson_tng_impl::get_rx_stream(const uhd::stream_args_t &args
                 // XXX: @CF: 20180214: Do we _really_ need to sleep 1/2s for power on for each channel??
                 //usleep( 500000 );
                 // stream enable
+                _tree->access<std::string>(rx_link_path / "stream").set("0");
                 _tree->access<std::string>(rx_link_path / "stream").set("1");
 
 // FIXME: @CF: 20180316: our TREE macros do not populate update(), unfortunately

--- a/host/lib/usrp/crimson_tng/io_impl.cpp
+++ b/host/lib/usrp/crimson_tng/io_impl.cpp
@@ -674,7 +674,6 @@ rx_streamer::sptr crimson_tng_impl::get_rx_stream(const uhd::stream_args_t &args
                 // XXX: @CF: 20180214: Do we _really_ need to sleep 1/2s for power on for each channel??
                 //usleep( 500000 );
                 // stream enable
-                _tree->access<std::string>(rx_link_path / "stream").set("0");
                 _tree->access<std::string>(rx_link_path / "stream").set("1");
 
 // FIXME: @CF: 20180316: our TREE macros do not populate update(), unfortunately

--- a/host/lib/usrp/multi_usrp.cpp
+++ b/host/lib/usrp/multi_usrp.cpp
@@ -222,145 +222,383 @@ static gain_fcns_t make_gain_fcns_from_subtree(property_tree::sptr subtree){
 static const double RX_SIGN = +1.0;
 static const double TX_SIGN = -1.0;
 
-static tune_result_t tune_xx_subdev_and_dsp(
-    const double xx_sign,
-    property_tree::sptr dsp_subtree,
-    property_tree::sptr rf_fe_subtree,
-    const tune_request_t &tune_request
-){
-    //------------------------------------------------------------------
-    //-- calculate the tunable frequency ranges of the system
-    //------------------------------------------------------------------
-    freq_range_t tune_range = make_overall_tune_range(
-            rf_fe_subtree->access<meta_range_t>("freq/range").get(),
-            dsp_subtree->access<meta_range_t>("freq/range").get(),
-            rf_fe_subtree->access<double>("bandwidth/value").get()
-        );
-
-    freq_range_t dsp_range = dsp_subtree->access<meta_range_t>("freq/range").get();
-    freq_range_t rf_range = rf_fe_subtree->access<meta_range_t>("freq/range").get();
-
-    double clipped_requested_freq = tune_range.clip(tune_request.target_freq);
-
-    //------------------------------------------------------------------
-    //-- If the RF FE requires an LO offset, build it into the tune request
-    //------------------------------------------------------------------
-
-    /*! The automatically calculated LO offset is only used if the
-     * 'use_lo_offset' field in the daughterboard property tree is set to TRUE,
-     * and the tune policy is set to AUTO. To use an LO offset normally, the
-     * user should specify the MANUAL tune policy and lo_offset as part of the
-     * tune_request. This lo_offset is based on the requirements of the FE, and
-     * does not reflect a user-requested lo_offset, which is handled later. */
-    double lo_offset = 0.0;
-    if (rf_fe_subtree->exists("use_lo_offset") and
-        rf_fe_subtree->access<bool>("use_lo_offset").get()){
-        // If the frontend has lo_offset value and range properties, trust it
-        // for lo_offset
-        if (rf_fe_subtree->exists("lo_offset/value")) {
-            lo_offset = rf_fe_subtree->access<double>("lo_offset/value").get();
-        }
-
-        //If the local oscillator will be in the passband, use an offset.
-        //But constrain the LO offset by the width of the filter bandwidth.
-        const double rate = dsp_subtree->access<double>("rate/value").get();
-        const double bw = rf_fe_subtree->access<double>("bandwidth/value").get();
-        if (bw > rate) lo_offset = std::min((bw - rate)/2, rate/2);
-    }
-
-    //------------------------------------------------------------------
-    //-- poke the tune request args into the dboard
-    //------------------------------------------------------------------
-    if (rf_fe_subtree->exists("tune_args")) {
-        rf_fe_subtree->access<device_addr_t>("tune_args").set(tune_request.args);
-    }
-
-    //------------------------------------------------------------------
-    //-- set the RF frequency depending upon the policy
-    //------------------------------------------------------------------
-    double target_rf_freq = 0.0;
-
-    switch (tune_request.rf_freq_policy){
-        case tune_request_t::POLICY_AUTO:
-            target_rf_freq = clipped_requested_freq + lo_offset;
-            break;
-
-        case tune_request_t::POLICY_MANUAL:
-            // If the rf_fe understands lo_offset settings, infer the desired
-            // lo_offset and set it. Side effect: In TVRX2 for example, after
-            // setting the lo_offset (if_freq) with a POLICY_MANUAL, there is no
-            // way for the user to automatically get back to default if_freq
-            // without deconstruct/reconstruct the rf_fe objects.
-            if (rf_fe_subtree->exists("lo_offset/value")) {
-                rf_fe_subtree->access<double>("lo_offset/value")
-                    .set(tune_request.rf_freq - tune_request.target_freq);
-            }
-
-            target_rf_freq = rf_range.clip(tune_request.rf_freq);
-            break;
-
-        case tune_request_t::POLICY_NONE:
-            break; //does not set
-    }
-
-    //------------------------------------------------------------------
-    //-- Tune the RF frontend
-    //------------------------------------------------------------------
-    if (tune_request.rf_freq_policy != tune_request_t::POLICY_NONE) {
-        rf_fe_subtree->access<double>("freq/value").set(target_rf_freq);
-    }
-    const double actual_rf_freq = rf_fe_subtree->access<double>("freq/value").get();
-
-    //------------------------------------------------------------------
-    //-- Set the DSP frequency depending upon the DSP frequency policy.
-    //------------------------------------------------------------------
-    double target_dsp_freq = 0.0;
-    switch (tune_request.dsp_freq_policy) {
-        case tune_request_t::POLICY_AUTO:
-            /* If we are using the AUTO tuning policy, then we prevent the
-             * CORDIC from spinning us outside of the range of the baseband
-             * filter, regardless of what the user requested. This could happen
-             * if the user requested a center frequency so far outside of the
-             * tunable range of the FE that the CORDIC would spin outside the
-             * filtered baseband. */
-            target_dsp_freq = actual_rf_freq - clipped_requested_freq;
-
-            //invert the sign on the dsp freq for transmit (spinning up vs down)
-            target_dsp_freq *= xx_sign;
-
-            break;
-
-        case tune_request_t::POLICY_MANUAL:
-            /* If the user has specified a manual tune policy, we will allow
-             * tuning outside of the baseband filter, but will still clip the
-             * target DSP frequency to within the bounds of the CORDIC to
-             * prevent undefined behavior (likely an overflow). */
-            target_dsp_freq = dsp_range.clip(tune_request.dsp_freq);
-            break;
-
-        case tune_request_t::POLICY_NONE:
-            break; //does not set
-    }
-
-    //------------------------------------------------------------------
-    //-- Tune the DSP
-    //------------------------------------------------------------------
-    if (tune_request.dsp_freq_policy != tune_request_t::POLICY_NONE) {
-        dsp_subtree->access<double>("freq/value").set(target_dsp_freq);
-    }
-    const double actual_dsp_freq = dsp_subtree->access<double>("freq/value").get();
-
-    //------------------------------------------------------------------
-    //-- Load and return the tune result
-    //------------------------------------------------------------------
-    tune_result_t tune_result;
-    tune_result.clipped_rf_freq = clipped_requested_freq;
-    tune_result.target_rf_freq = target_rf_freq;
-    tune_result.actual_rf_freq = actual_rf_freq;
-    tune_result.target_dsp_freq = target_dsp_freq;
-    tune_result.actual_dsp_freq = actual_dsp_freq;
-    return tune_result;
+// XXX: @CF: 20180418: stop-gap until moved to server
+static bool is_high_band( const meta_range_t &dsp_range, const double freq, double bw ) {
+	return freq + bw / 2.0 >= dsp_range.stop();
 }
+
+// XXX: @CF: 20180418: stop-gap until moved to server
+// return true if b is a (not necessarily strict) subset of a
+static bool range_contains( const meta_range_t & a, const meta_range_t & b ) {
+	return b.start() >= a.start() && b.stop() <= a.stop();
+}
+
+// XXX: @CF: 20180418: stop-gap until moved to server
+static double choose_dsp_nco_shift( double target_freq, property_tree::sptr dsp_subtree ) {
+
+	/*
+	 * Scenario 1) Channels A and B
+	 *
+	 * We want a shift such that the full bandwidth fits inside of one of the
+	 * dashed regions.
+	 *
+	 * Our margin around each sensitive area is 1 MHz on either side.
+	 *
+	 * In order of increasing bandwidth & minimal interference, our
+	 * preferences are
+	 *
+	 * Region A
+	 * Region B
+	 * Region F
+	 * Region G
+	 * Region H
+	 *
+	 * Region A is preferred because it exhibits the least attenuation. B is
+	 * preferred over C for that reason (and because it has a more bandwidth
+	 * than C). F is the next largest band and is preferred over E because
+	 * it avoids the LO fundamental, but it contains FM. G is the next-to-last
+	 * preference because it includes the LO and FM but has a very large
+	 * bandwidth. Finally, H is the catch-all. It suffers at high frequencies
+	 * due to the ADC filterbank, but includes the entirety of the spectrum.
+	 *
+	[--]-------------------[+]-----------------------+-------------------------+-----------[///////////+////////]---------------+------------[\\\\\\\\\\\+\\\\\\\\\\\\\\>
+	 | |                    |                                                              |                    |                            |                      |    f (MHz)
+	 0 2                    25                                                           87.9                  107.9                        137                    162.5
+	DC                 LO fundamental                                                               FM                                   ADC Cutoff            Max Samp Rate
+           A (21 MHz)                            B (60.9 MHz)                                                             C (27.1 Mhz)                 D (26.5 MHz)
+                           E = A + B (includes LO)                                                                     F = B + C (includes FM)
+					                                           G = A + B + C
+					                                           H = A + B + C + D
+	 */
+	static const std::vector<freq_range_t> AB_regions {
+		freq_range_t( 3e6, 24e6 ), // A
+		freq_range_t( 26e6, 86.9e6 ), // B
+		freq_range_t( 26e6, 136e6 ), // F = B + C
+		freq_range_t( 3e6, 136e6 ), // G = A + B + C
+		freq_range_t( 3e6, 162.5e6 ), // H = A + B + C + D (Catch All)
+		freq_range_t( -162.5e6, 162.5e6 ), // I = 2*H (Catch All)
+	};
+	/*
+	 * Scenario 2) Channels C and D
+	 *
+	 * Channels C & D only provide 1/2 the bandwidth of A & B due to silicon
+	 * errata. This should be corrected in subsequent hardware revisions of
+	 * Crimson.
+	 *
+	 * In order of increasing bandwidth & minimal interference, our
+	 * preferences are
+	 *
+	 * Region A
+	 * Region B
+	 * Region C
+	[--]-------------------[+]-----------------------+-------------------------+---->
+	 | |                    |                                                  |    f (MHz)
+	 0 2                    25                                               81.25
+	DC                 LO fundamental                                      Max Samp Rate
+           A (21 MHz)                            B (55.25 MHz)
+                           C = A + B (includes LO)
+	 */
+	static const std::vector<freq_range_t> CD_regions {
+		freq_range_t( 3e6, 24e6 ), // A
+		freq_range_t( 26e6, 81.25e6 ), // B
+		freq_range_t( 3e6, 81.25e6 ), // C = A + B (Catch All)
+		freq_range_t( -81.25e6, 81.25e6 ), // I = 2*H (Catch All)
+	};
+	// XXX: @CF: TODO: Dynamically construct data structure upon init when KB #3926 is addressed
+
+	static const double lo_step = 25e6;
+
+	const meta_range_t dsp_range = dsp_subtree->access<meta_range_t>( "/freq/range" ).get();
+	const char channel = ( dsp_range.stop() - dsp_range.start() ) > 81.25e6 ? 'A' : 'C';
+	const double bw = dsp_subtree->access<double>("/rate/value").get();
+	const std::vector<freq_range_t> & regions =
+		( 'A' == channel || 'B' == channel )
+		? AB_regions
+		: CD_regions
+	;
+	const int K = (int) floor( ( dsp_range.stop() - dsp_range.start() ) / lo_step );
+
+	for( int k = 0; k <= K; k++ ) {
+		for( double sign: { +1, -1 } ) {
+
+			double candidate_lo = target_freq;
+			if ( sign > 0 ) {
+				// If sign > 0 we set the LO sequentially higher multiples of LO STEP
+				// above the target frequency
+				candidate_lo += lo_step - fmod( target_freq, lo_step );
+			} else {
+				// If sign < 0 we set the LO sequentially lower multiples of LO STEP
+				// above the target frequency
+				candidate_lo -= fmod( target_freq, lo_step );
+			}
+			candidate_lo += k * sign * lo_step;
+
+			const double candidate_nco = target_freq - candidate_lo;
+			const double bb_ft = target_freq - candidate_lo + candidate_nco;
+			const meta_range_t candidate_range( bb_ft - bw / 2, bb_ft + bw / 2 );
+
+			for( const freq_range_t & _range: regions ) {
+				if ( range_contains( _range, candidate_range ) ) {
+					return candidate_nco;
+				}
+			}
+		}
+	}
+
+	// Under normal operating parameters, this should never happen because
+	// the last-choice _range in each of AB_regions and CD_regions is
+	// a catch-all for the entire DSP bandwidth. Hitting this scenario is
+	// equivalent to saying that the LO is incapable of up / down mixing
+	// the RF signal into the baseband domain.
+	throw runtime_error(
+		(
+			boost::format( "No suitable baseband region found: target_freq: %f, bw: %f, dsp_range: %s" )
+			% target_freq
+			% bw
+			% dsp_range.to_pp_string()
+		).str()
+	);
+}
+
+// XXX: @CF: 20180418: stop-gap until moved to server
+static tune_result_t tune_xx_subdev_and_dsp( const double xx_sign, property_tree::sptr dsp_subtree, property_tree::sptr rf_fe_subtree, const tune_request_t &tune_request ) {
+
+	enum {
+		LOW_BAND,
+		HIGH_BAND,
+	};
+
+	freq_range_t dsp_range = dsp_subtree->access<meta_range_t>("freq/range").get();
+	freq_range_t rf_range = rf_fe_subtree->access<meta_range_t>("freq/range").get();
+	freq_range_t adc_range( dsp_range.start(), 137e6, 0.0001 );
+	freq_range_t & min_range = dsp_range.stop() < adc_range.stop() ? dsp_range : adc_range;
+
+	double clipped_requested_freq = rf_range.clip( tune_request.target_freq );
+	double bw = dsp_subtree->access<double>( "/rate/value" ).get();
+
+	int band = is_high_band( min_range, clipped_requested_freq, bw ) ? HIGH_BAND : LOW_BAND;
+
+	//------------------------------------------------------------------
+	//-- set the RF frequency depending upon the policy
+	//------------------------------------------------------------------
+	double target_rf_freq = 0.0;
+	double dsp_nco_shift = 0;
+
+	// kb #3689, for phase coherency, we must set the DAC NCO to 0
+	if ( TX_SIGN == xx_sign ) {
+		rf_fe_subtree->access<double>("nco").set( 0.0 );
+	}
+
+	rf_fe_subtree->access<int>( "freq/band" ).set( band );
+
+	switch (tune_request.rf_freq_policy){
+		case tune_request_t::POLICY_AUTO:
+			switch( band ) {
+			case LOW_BAND:
+				// in low band, we only use the DSP to tune
+				target_rf_freq = 0;
+				break;
+			case HIGH_BAND:
+				dsp_nco_shift = choose_dsp_nco_shift( clipped_requested_freq, dsp_subtree );
+				// in high band, we use the LO for most of the shift, and use the DSP for the difference
+				target_rf_freq = rf_range.clip( clipped_requested_freq - dsp_nco_shift );
+				break;
+			}
+		break;
+
+		case tune_request_t::POLICY_MANUAL:
+			target_rf_freq = rf_range.clip( tune_request.rf_freq );
+			break;
+
+		case tune_request_t::POLICY_NONE:
+			break; //does not set
+	}
+
+	//------------------------------------------------------------------
+	//-- Tune the RF frontend
+	//------------------------------------------------------------------
+	rf_fe_subtree->access<double>("freq/value").set( target_rf_freq );
+	const double actual_rf_freq = rf_fe_subtree->access<double>("freq/value").get();
+
+	//------------------------------------------------------------------
+	//-- Set the DSP frequency depending upon the DSP frequency policy.
+	//------------------------------------------------------------------
+	double target_dsp_freq = 0.0;
+	switch (tune_request.dsp_freq_policy) {
+		case tune_request_t::POLICY_AUTO:
+			target_dsp_freq = actual_rf_freq - clipped_requested_freq;
+
+			//invert the sign on the dsp freq for transmit (spinning up vs down)
+			target_dsp_freq *= xx_sign;
+
+			break;
+
+		case tune_request_t::POLICY_MANUAL:
+			target_dsp_freq = tune_request.dsp_freq;
+			break;
+
+		case tune_request_t::POLICY_NONE:
+			break; //does not set
+	}
+
+	//------------------------------------------------------------------
+	//-- Tune the DSP
+	//------------------------------------------------------------------
+	dsp_subtree->access<double>("freq/value").set(target_dsp_freq);
+	const double actual_dsp_freq = dsp_subtree->access<double>("freq/value").get();
+
+	//------------------------------------------------------------------
+	//-- Load and return the tune result
+	//------------------------------------------------------------------
+	tune_result_t tune_result;
+	tune_result.clipped_rf_freq = clipped_requested_freq;
+	tune_result.target_rf_freq = target_rf_freq;
+	tune_result.actual_rf_freq = actual_rf_freq;
+	tune_result.target_dsp_freq = target_dsp_freq;
+	tune_result.actual_dsp_freq = actual_dsp_freq;
+	return tune_result;
+}
+
+
+//static tune_result_t tune_xx_subdev_and_dsp(
+//    const double xx_sign,
+//    property_tree::sptr dsp_subtree,
+//    property_tree::sptr rf_fe_subtree,
+//    const tune_request_t &tune_request
+//){
+//    //------------------------------------------------------------------
+//    //-- calculate the tunable frequency ranges of the system
+//    //------------------------------------------------------------------
+//    freq_range_t tune_range = make_overall_tune_range(
+//            rf_fe_subtree->access<meta_range_t>("freq/range").get(),
+//            dsp_subtree->access<meta_range_t>("freq/range").get(),
+//            rf_fe_subtree->access<double>("bandwidth/value").get()
+//        );
+//
+//    freq_range_t dsp_range = dsp_subtree->access<meta_range_t>("freq/range").get();
+//    freq_range_t rf_range = rf_fe_subtree->access<meta_range_t>("freq/range").get();
+//
+//    double clipped_requested_freq = tune_range.clip(tune_request.target_freq);
+//
+//    //------------------------------------------------------------------
+//    //-- If the RF FE requires an LO offset, build it into the tune request
+//    //------------------------------------------------------------------
+//
+//    /*! The automatically calculated LO offset is only used if the
+//     * 'use_lo_offset' field in the daughterboard property tree is set to TRUE,
+//     * and the tune policy is set to AUTO. To use an LO offset normally, the
+//     * user should specify the MANUAL tune policy and lo_offset as part of the
+//     * tune_request. This lo_offset is based on the requirements of the FE, and
+//     * does not reflect a user-requested lo_offset, which is handled later. */
+//    double lo_offset = 0.0;
+//    if (rf_fe_subtree->exists("use_lo_offset") and
+//        rf_fe_subtree->access<bool>("use_lo_offset").get()){
+//        // If the frontend has lo_offset value and range properties, trust it
+//        // for lo_offset
+//        if (rf_fe_subtree->exists("lo_offset/value")) {
+//            lo_offset = rf_fe_subtree->access<double>("lo_offset/value").get();
+//        }
+//
+//        //If the local oscillator will be in the passband, use an offset.
+//        //But constrain the LO offset by the width of the filter bandwidth.
+//        const double rate = dsp_subtree->access<double>("rate/value").get();
+//        const double bw = rf_fe_subtree->access<double>("bandwidth/value").get();
+//        if (bw > rate) lo_offset = std::min((bw - rate)/2, rate/2);
+//    }
+//
+//    //------------------------------------------------------------------
+//    //-- poke the tune request args into the dboard
+//    //------------------------------------------------------------------
+//    if (rf_fe_subtree->exists("tune_args")) {
+//        rf_fe_subtree->access<device_addr_t>("tune_args").set(tune_request.args);
+//    }
+//
+//    //------------------------------------------------------------------
+//    //-- set the RF frequency depending upon the policy
+//    //------------------------------------------------------------------
+//    double target_rf_freq = 0.0;
+//
+//    switch (tune_request.rf_freq_policy){
+//        case tune_request_t::POLICY_AUTO:
+//            target_rf_freq = clipped_requested_freq + lo_offset;
+//            break;
+//
+//        case tune_request_t::POLICY_MANUAL:
+//            // If the rf_fe understands lo_offset settings, infer the desired
+//            // lo_offset and set it. Side effect: In TVRX2 for example, after
+//            // setting the lo_offset (if_freq) with a POLICY_MANUAL, there is no
+//            // way for the user to automatically get back to default if_freq
+//            // without deconstruct/reconstruct the rf_fe objects.
+//            if (rf_fe_subtree->exists("lo_offset/value")) {
+//                rf_fe_subtree->access<double>("lo_offset/value")
+//                    .set(tune_request.rf_freq - tune_request.target_freq);
+//            }
+//
+//            target_rf_freq = rf_range.clip(tune_request.rf_freq);
+//            break;
+//
+//        case tune_request_t::POLICY_NONE:
+//            break; //does not set
+//    }
+//
+//    //------------------------------------------------------------------
+//    //-- Tune the RF frontend
+//    //------------------------------------------------------------------
+//    if (tune_request.rf_freq_policy != tune_request_t::POLICY_NONE) {
+//        rf_fe_subtree->access<double>("freq/value").set(target_rf_freq);
+//    }
+//    const double actual_rf_freq = rf_fe_subtree->access<double>("freq/value").get();
+//
+//    //------------------------------------------------------------------
+//    //-- Set the DSP frequency depending upon the DSP frequency policy.
+//    //------------------------------------------------------------------
+//    double target_dsp_freq = 0.0;
+//    switch (tune_request.dsp_freq_policy) {
+//        case tune_request_t::POLICY_AUTO:
+//            /* If we are using the AUTO tuning policy, then we prevent the
+//             * CORDIC from spinning us outside of the range of the baseband
+//             * filter, regardless of what the user requested. This could happen
+//             * if the user requested a center frequency so far outside of the
+//             * tunable range of the FE that the CORDIC would spin outside the
+//             * filtered baseband. */
+//            target_dsp_freq = actual_rf_freq - clipped_requested_freq;
+//
+//            //invert the sign on the dsp freq for transmit (spinning up vs down)
+//            target_dsp_freq *= xx_sign;
+//
+//            break;
+//
+//        case tune_request_t::POLICY_MANUAL:
+//            /* If the user has specified a manual tune policy, we will allow
+//             * tuning outside of the baseband filter, but will still clip the
+//             * target DSP frequency to within the bounds of the CORDIC to
+//             * prevent undefined behavior (likely an overflow). */
+//            target_dsp_freq = dsp_range.clip(tune_request.dsp_freq);
+//            break;
+//
+//        case tune_request_t::POLICY_NONE:
+//            break; //does not set
+//    }
+//
+//    //------------------------------------------------------------------
+//    //-- Tune the DSP
+//    //------------------------------------------------------------------
+//    if (tune_request.dsp_freq_policy != tune_request_t::POLICY_NONE) {
+//        dsp_subtree->access<double>("freq/value").set(target_dsp_freq);
+//    }
+//    const double actual_dsp_freq = dsp_subtree->access<double>("freq/value").get();
+//
+//    //------------------------------------------------------------------
+//    //-- Load and return the tune result
+//    //------------------------------------------------------------------
+//    tune_result_t tune_result;
+//    tune_result.clipped_rf_freq = clipped_requested_freq;
+//    tune_result.target_rf_freq = target_rf_freq;
+//    tune_result.actual_rf_freq = actual_rf_freq;
+//    tune_result.target_dsp_freq = target_dsp_freq;
+//    tune_result.actual_dsp_freq = actual_dsp_freq;
+//    return tune_result;
+//}
 
 static double derive_freq_from_xx_subdev_and_dsp(
     const double xx_sign,
@@ -863,9 +1101,18 @@ public:
         return result;
     }
 
+    // XXX: @CF: 20180418: stop-gap until moved to server
     double get_rx_freq(size_t chan){
-        return derive_freq_from_xx_subdev_and_dsp(RX_SIGN, _tree->subtree(rx_dsp_root(chan)), _tree->subtree(rx_rf_fe_root(chan)));
+        double cur_dsp_nco = _tree->access<double>(rx_dsp_root(chan) / "nco").get();
+        double cur_lo_freq = 0;
+        if (_tree->access<int>(rx_rf_fe_root(chan) / "freq" / "band").get() == 1) {
+            cur_lo_freq = _tree->access<double>(rx_rf_fe_root(chan) / "freq" / "value").get();
+        }
+        return cur_lo_freq - cur_dsp_nco;
     }
+//    double get_rx_freq(size_t chan){
+//        return derive_freq_from_xx_subdev_and_dsp(RX_SIGN, _tree->subtree(rx_dsp_root(chan)), _tree->subtree(rx_rf_fe_root(chan)));
+//    }
 
     freq_range_t get_rx_freq_range(size_t chan){
         return make_overall_tune_range(
@@ -1264,33 +1511,120 @@ public:
     /**************************************************************************
      * Gain control
      *************************************************************************/
-    void set_rx_gain(double gain, const std::string &name, size_t chan){
-        /* Check if any AGC mode is enable and if so warn the user */
-        if (chan != ALL_CHANS) {
-            if (_tree->exists(rx_rf_fe_root(chan) / "gain" / "agc")) {
-                bool agc = _tree->access<bool>(rx_rf_fe_root(chan) / "gain" / "agc" / "enable").get();
-                if(agc) {
-                    UHD_LOGGER_WARNING("MULTI_USRP") << "AGC enabled for this channel. Setting will be ignored." ;
-                }
-            }
-        } else {
-            for (size_t c = 0; c < get_rx_num_channels(); c++){
-                if (_tree->exists(rx_rf_fe_root(c) / "gain" / "agc")) {
-                    bool agc = _tree->access<bool>(rx_rf_fe_root(chan) / "gain" / "agc" / "enable").get();
-                    if(agc) {
-                        UHD_LOGGER_WARNING("MULTI_USRP") << "AGC enabled for this channel. Setting will be ignored." ;
-                    }
-                }
-            }
-        }
-        /* Apply gain setting.
-         * If device is in AGC mode it will ignore the setting. */
-        try {
-            return rx_gain_group(chan)->set_value(gain, name);
-        } catch (uhd::key_error &) {
-            THROW_GAIN_NAME_ERROR(name,chan,rx);
+	#include "crimson_tng/crimson_tng_fw_common.h"
+    void set_rx_gain(double gain, const std::string &name, size_t chan) {
+
+    	if ( ALL_CHANS != chan ) {
+
+    		(void) name;
+
+    		double atten_val = 0;
+    		double gain_val = 0;
+    		double lna_val = 0;
+
+    		gain = gain < CRIMSON_TNG_RF_RX_GAIN_RANGE_START ? CRIMSON_TNG_RF_RX_GAIN_RANGE_START : gain;
+    		gain = gain > CRIMSON_TNG_RF_RX_GAIN_RANGE_STOP ? CRIMSON_TNG_RF_RX_GAIN_RANGE_STOP : gain;
+
+    		if ( 0 == _tree->access<int>(rx_rf_fe_root(chan) / "freq" / "band").get() ) {
+    			// Low-Band
+
+    			double low_band_gain = gain > 31.5 ? 31.5 : gain;
+
+    			if ( low_band_gain != gain ) {
+    				boost::format rf_lo_message(
+    					"  The RF Low Band does not support the requested gain:\n"
+    					"    Requested RF Low Band gain: %f dB\n"
+    					"    Actual RF Low Band gain: %f dB\n"
+    				);
+    				rf_lo_message % gain % low_band_gain;
+    				std::string results_string = rf_lo_message.str();
+    				UHD_LOGGER_INFO("MULTI_CRIMSON") << results_string;
+    			}
+
+    			// PMA is off (+0dB)
+    			lna_val = 0;
+    			// BFP is off (+0dB)
+    			// PE437 fully attenuates the BFP (-20 dB) AND THEN SOME
+    			atten_val = 31.75;
+    			// LMH is adjusted from 0dB to 31.5dB
+    			gain_val = low_band_gain;
+
+    		} else {
+    			// High-Band
+
+    			if ( false ) {
+    			} else if ( CRIMSON_TNG_RF_RX_GAIN_RANGE_START <= gain && gain <= 31.5 ) {
+    				// PMA is off (+0dB)
+    				lna_val = 0;
+    				// BFP is on (+20dB)
+    				// PE437 fully attenuates BFP (-20dB) AND THEN SOME (e.g. to attenuate interferers)
+    				atten_val = 31.75;
+    				// LMH is adjusted from 0dB to 31.5dB
+    				gain_val = gain;
+    			} else if ( 31.5 < gain && gain <= 63.25 ) {
+    				// PMA is off (+0dB)
+    				lna_val = 0;
+    				// BFP is on (+20dB)
+    				// PE437 is adjusted from -31.75 dB to 0dB
+    				atten_val = 63.25 - gain;
+    				// LMH is maxed (+31.5dB)
+    				gain_val = 31.5;
+    			} else if ( 63.25 < gain && gain <= CRIMSON_TNG_RF_RX_GAIN_RANGE_STOP ) {
+    				// PMA is on (+20dB)
+    				lna_val = 20;
+    				// BFP is on (+20dB)
+    				// PE437 is adjusted from -20 dB to 0dB
+    				atten_val = CRIMSON_TNG_RF_RX_GAIN_RANGE_STOP - gain;
+    				// LMH is maxed (+31.5dB)
+    				gain_val = 31.5;
+    			}
+    		}
+
+    		int lna_bypass_enable = 0 == lna_val ? 1 : 0;
+    		_tree->access<int>( rx_rf_fe_root(chan) / "freq" / "lna" ).set( lna_bypass_enable );
+
+    		//if ( 0 == _tree->access<int>( cm_root() / "chanmask-rx" ).get() ) {
+    			_tree->access<double>( rx_rf_fe_root(chan) / "atten" / "value" ).set( atten_val * 4 );
+    			_tree->access<double>( rx_rf_fe_root(chan) / "gain" / "value" ).set( gain_val * 4 );
+    		//} else {
+    		//	_tree->access<double>( cm_root() / "rx/atten/val" ).set( atten_val * 4 );
+    		//	_tree->access<double>( cm_root() / "rx/gain/val" ).set( gain_val * 4 );
+    		//}
+    		return;
+    	}
+
+        for (size_t c = 0; c < get_rx_num_channels(); c++){
+            set_rx_gain( gain, name, c );
         }
     }
+
+//    void set_rx_gain(double gain, const std::string &name, size_t chan){
+//        /* Check if any AGC mode is enable and if so warn the user */
+//        if (chan != ALL_CHANS) {
+//            if (_tree->exists(rx_rf_fe_root(chan) / "gain" / "agc")) {
+//                bool agc = _tree->access<bool>(rx_rf_fe_root(chan) / "gain" / "agc" / "enable").get();
+//                if(agc) {
+//                    UHD_LOGGER_WARNING("MULTI_USRP") << "AGC enabled for this channel. Setting will be ignored." ;
+//                }
+//            }
+//        } else {
+//            for (size_t c = 0; c < get_rx_num_channels(); c++){
+//                if (_tree->exists(rx_rf_fe_root(c) / "gain" / "agc")) {
+//                    bool agc = _tree->access<bool>(rx_rf_fe_root(chan) / "gain" / "agc" / "enable").get();
+//                    if(agc) {
+//                        UHD_LOGGER_WARNING("MULTI_USRP") << "AGC enabled for this channel. Setting will be ignored." ;
+//                    }
+//                }
+//            }
+//        }
+//        /* Apply gain setting.
+//         * If device is in AGC mode it will ignore the setting. */
+//        try {
+//            return rx_gain_group(chan)->set_value(gain, name);
+//        } catch (uhd::key_error &) {
+//            THROW_GAIN_NAME_ERROR(name,chan,rx);
+//        }
+//    }
 
     void set_rx_gain_profile(const std::string& profile, const size_t chan){
         if (chan != ALL_CHANS) {
@@ -1365,13 +1699,35 @@ public:
 
     }
 
+    // get RX frontend gain on specified channel
     double get_rx_gain(const std::string &name, size_t chan){
-        try {
-            return rx_gain_group(chan)->get_value(name);
-        } catch (uhd::key_error &) {
-            THROW_GAIN_NAME_ERROR(name,chan,rx);
-        }
+
+    	(void)name;
+    	(void)chan;
+
+    	double r;
+
+    	bool lna_bypass_enable = 0 == _tree->access<int>(rx_rf_fe_root(chan) / "freq" / "lna").get() ? false : true;
+        double lna_val = lna_bypass_enable ? 0 : 20;
+        double gain_val  = _tree->access<double>(rx_rf_fe_root(chan) / "gain"  / "value").get() / 4;
+        double atten_val = _tree->access<double>(rx_rf_fe_root(chan) / "atten" / "value").get() / 4;
+
+    	if ( 0 == _tree->access<int>(rx_rf_fe_root(chan) / "freq" / "band").get() ) {
+    		r = gain_val;
+    	} else {
+    		r = 31.75 - atten_val + lna_val + gain_val; // maximum is 83.25
+    	}
+
+        return r;
     }
+
+//    double get_rx_gain(const std::string &name, size_t chan){
+//        try {
+//            return rx_gain_group(chan)->get_value(name);
+//        } catch (uhd::key_error &) {
+//            THROW_GAIN_NAME_ERROR(name,chan,rx);
+//        }
+//    }
 
     double get_normalized_rx_gain(size_t chan)
     {
@@ -1674,9 +2030,19 @@ public:
         return result;
     }
 
+    // XXX: @CF: 20180418: stop-gap until moved to server
     double get_tx_freq(size_t chan){
-        return derive_freq_from_xx_subdev_and_dsp(TX_SIGN, _tree->subtree(tx_dsp_root(chan)), _tree->subtree(tx_rf_fe_root(chan)));
+        double cur_dac_nco = _tree->access<double>(tx_rf_fe_root(chan) / "nco").get();
+        double cur_dsp_nco = _tree->access<double>(tx_dsp_root(chan) / "nco").get();
+        double cur_lo_freq = 0;
+        if (_tree->access<int>(tx_rf_fe_root(chan) / "freq" / "band").get() == 1) {
+        	cur_lo_freq = _tree->access<double>(tx_rf_fe_root(chan) / "freq" / "value").get();
+        }
+        return cur_lo_freq + cur_dac_nco + cur_dsp_nco;
     }
+//    double get_tx_freq(size_t chan){
+//        return derive_freq_from_xx_subdev_and_dsp(TX_SIGN, _tree->subtree(tx_dsp_root(chan)), _tree->subtree(tx_rf_fe_root(chan)));
+//    }
 
     freq_range_t get_tx_freq_range(size_t chan){
         return make_overall_tune_range(

--- a/host/lib/usrp/multi_usrp.cpp
+++ b/host/lib/usrp/multi_usrp.cpp
@@ -27,8 +27,6 @@
 #include <cmath>
 #include <bitset>
 
-#include "uhd/usrp/multi_crimson_tng.hpp"
-
 using namespace uhd;
 using namespace uhd::usrp;
 
@@ -465,6 +463,23 @@ public:
 
     double get_master_clock_rate(size_t mboard){
         return _tree->access<double>(mb_root(mboard) / "tick_rate").get();
+    }
+
+    meta_range_t get_master_clock_rate_range(const size_t mboard)
+    {
+        if (_tree->exists(mb_root(mboard) / "tick_rate/range")) {
+            return _tree->access<meta_range_t>(
+                mb_root(mboard) / "tick_rate/range"
+            ).get();
+        }
+        // The USRP may not have a range defined, in which case we create a
+        // fake range with a single value:
+        const double tick_rate = get_master_clock_rate(mboard);
+        return meta_range_t(
+            tick_rate,
+            tick_rate,
+            0
+        );
     }
 
     std::string get_pp_string(void){
@@ -1862,158 +1877,195 @@ public:
         return banks;
     }
 
-    void set_gpio_attr(const std::string &bank, const std::string &attr, const uint32_t value, const uint32_t mask, const size_t mboard)
-    {
+    void set_gpio_attr(
+        const std::string &bank,
+        const std::string &attr,
+        const uint32_t value,
+        const uint32_t mask,
+        const size_t mboard
+    ) {
         std::vector<std::string> attr_value;
-        if (_tree->exists(mb_root(mboard) / "gpio" / bank))
-        {
+        if (_tree->exists(mb_root(mboard) / "gpio" / bank)) {
             if (_tree->exists(mb_root(mboard) / "gpio" / bank / attr)){
-                gpio_atr::gpio_attr_t attr_type = gpio_atr::gpio_attr_rev_map.at(attr);
-                switch (attr_type){
+                const auto attr_type = gpio_atr::gpio_attr_rev_map.at(attr);
+                switch (attr_type) {
                     case gpio_atr::GPIO_SRC:
-                        throw uhd::runtime_error("Can't set SRC attribute using u32int_t value");
+                        throw uhd::runtime_error(
+                            "Can't set SRC attribute using integer value!"
+                        );
                         break;
                     case gpio_atr::GPIO_CTRL:
-                    case gpio_atr::GPIO_DDR:{
-                        attr_value = _tree->access<std::vector<std::string>>(mb_root(mboard) / "gpio" / bank / attr).get();
+                    case gpio_atr::GPIO_DDR: {
+                        attr_value = _tree->access<std::vector<std::string>>(
+                            mb_root(mboard) / "gpio" / bank / attr
+                        ).get();
                         UHD_ASSERT_THROW(attr_value.size() <= 32);
                         std::bitset<32> bit_mask = std::bitset<32>(mask);
                         std::bitset<32> bit_value = std::bitset<32>(value);
-                        for (size_t i = 0 ; i < bit_mask.size();i++){
-                            if (bit_mask[i] == 1){
+                        for (size_t i = 0; i < bit_mask.size(); i++) {
+                            if (bit_mask[i] == 1) {
                                 attr_value[i] = gpio_atr::attr_value_map.at(attr_type).at(bit_value[i]);
                             }
                         }
-                        _tree->access<std::vector<std::string>>(mb_root(mboard) / "gpio" / bank / attr).set(attr_value);
+                        _tree->access<std::vector<std::string>>(
+                            mb_root(mboard) / "gpio" / bank / attr
+                        ).set(attr_value);
                     }
-                        break;
+                    break;
                     default:{
-                        const uint32_t current = _tree->access<uint32_t>(mb_root(mboard) / "gpio" / bank / attr).get();
+                        const uint32_t current = _tree->access<uint32_t>(
+                            mb_root(mboard) / "gpio" / bank / attr).get();
                         const uint32_t new_value = (current & ~mask) | (value & mask);
                         _tree->access<uint32_t>(mb_root(mboard) / "gpio" / bank / attr).set(new_value);
                     }
-                        break;
+                    break;
                 }
                 return;
-            }else{
-                throw uhd::runtime_error(str(boost::format(
-                    "The hardware has no gpio attribute: %s:\n") % attr));
+            } else {
+                throw uhd::runtime_error(str(
+                    boost::format("The hardware has no gpio attribute: `%s':\n")
+                    % attr
+                ));
             }
         }
-        if (bank.size() > 2 and bank[1] == 'X')
-        {
+        if (bank.size() > 2 and bank[1] == 'X') {
             const std::string name = bank.substr(2);
-            const dboard_iface::unit_t unit = (bank[0] == 'R')? dboard_iface::UNIT_RX : dboard_iface::UNIT_TX;
-            dboard_iface::sptr iface = _tree->access<dboard_iface::sptr>(mb_root(mboard) / "dboards" / name / "iface").get();
-            if (attr == gpio_atr::gpio_attr_map.at(gpio_atr::GPIO_CTRL)) iface->set_pin_ctrl(unit, uint16_t(value), uint16_t(mask));
-            if (attr == gpio_atr::gpio_attr_map.at(gpio_atr::GPIO_DDR)) iface->set_gpio_ddr(unit, uint16_t(value), uint16_t(mask));
-            if (attr == gpio_atr::gpio_attr_map.at(gpio_atr::GPIO_OUT)) iface->set_gpio_out(unit, uint16_t(value), uint16_t(mask));
-            if (attr == gpio_atr::gpio_attr_map.at(gpio_atr::GPIO_ATR_0X)) iface->set_atr_reg(unit, gpio_atr::ATR_REG_IDLE, uint16_t(value), uint16_t(mask));
-            if (attr == gpio_atr::gpio_attr_map.at(gpio_atr::GPIO_ATR_RX)) iface->set_atr_reg(unit, gpio_atr::ATR_REG_RX_ONLY, uint16_t(value), uint16_t(mask));
-            if (attr == gpio_atr::gpio_attr_map.at(gpio_atr::GPIO_ATR_TX)) iface->set_atr_reg(unit, gpio_atr::ATR_REG_TX_ONLY, uint16_t(value), uint16_t(mask));
-            if (attr == gpio_atr::gpio_attr_map.at(gpio_atr::GPIO_ATR_XX)) iface->set_atr_reg(unit, gpio_atr::ATR_REG_FULL_DUPLEX, uint16_t(value), uint16_t(mask));
-            if (attr == gpio_atr::gpio_attr_map.at(gpio_atr::GPIO_SRC)){
+            const dboard_iface::unit_t unit =
+                (bank[0] == 'R')
+                ? dboard_iface::UNIT_RX
+                : dboard_iface::UNIT_TX;
+            auto iface = _tree->access<dboard_iface::sptr>(
+                mb_root(mboard) / "dboards" / name / "iface").get();
+            if (attr == gpio_atr::gpio_attr_map.at(gpio_atr::GPIO_CTRL))
+                iface->set_pin_ctrl(unit, uint16_t(value), uint16_t(mask));
+            if (attr == gpio_atr::gpio_attr_map.at(gpio_atr::GPIO_DDR))
+                iface->set_gpio_ddr(unit, uint16_t(value), uint16_t(mask));
+            if (attr == gpio_atr::gpio_attr_map.at(gpio_atr::GPIO_OUT))
+                iface->set_gpio_out(unit, uint16_t(value), uint16_t(mask));
+            if (attr == gpio_atr::gpio_attr_map.at(gpio_atr::GPIO_ATR_0X))
+                iface->set_atr_reg(unit, gpio_atr::ATR_REG_IDLE, uint16_t(value), uint16_t(mask));
+            if (attr == gpio_atr::gpio_attr_map.at(gpio_atr::GPIO_ATR_RX))
+                iface->set_atr_reg(unit, gpio_atr::ATR_REG_RX_ONLY, uint16_t(value), uint16_t(mask));
+            if (attr == gpio_atr::gpio_attr_map.at(gpio_atr::GPIO_ATR_TX))
+                iface->set_atr_reg(unit, gpio_atr::ATR_REG_TX_ONLY, uint16_t(value), uint16_t(mask));
+            if (attr == gpio_atr::gpio_attr_map.at(gpio_atr::GPIO_ATR_XX))
+                iface->set_atr_reg(unit, gpio_atr::ATR_REG_FULL_DUPLEX, uint16_t(value), uint16_t(mask));
+            if (attr == gpio_atr::gpio_attr_map.at(gpio_atr::GPIO_SRC)) {
                 throw uhd::runtime_error("Setting gpio source does not supported in daughter board.");
             }
             return;
         }
-        throw uhd::runtime_error(str(boost::format(
-            "The hardware has no gpio bank: %s:\n") % bank));
+        throw uhd::runtime_error(str(
+            boost::format("The hardware has no GPIO bank `%s'")
+            % bank
+        ));
     }
 
-    void set_gpio_attr(const std::string &bank, const std::string &attr, const std::string &str_value , const uint32_t mask, const size_t mboard)
-    {
-
-        gpio_atr::gpio_attr_t attr_type = gpio_atr::gpio_attr_rev_map.at(attr);
-
-        if (_tree->exists(mb_root(mboard) / "gpio" / bank))
-        {
-            if (_tree->exists(mb_root(mboard) / "gpio" / bank / attr)){
-
+    void set_gpio_attr(
+            const std::string &bank,
+            const std::string &attr,
+            const std::string &str_value,
+            const uint32_t mask,
+            const size_t mboard
+    ) {
+        const auto attr_type = gpio_atr::gpio_attr_rev_map.at(attr);
+        if (_tree->exists(mb_root(mboard) / "gpio" / bank)) {
+            if (_tree->exists(mb_root(mboard) / "gpio" / bank / attr)) {
                 switch (attr_type){
                     case gpio_atr::GPIO_SRC:
                     case gpio_atr::GPIO_CTRL:
                     case gpio_atr::GPIO_DDR:{
-                         std::vector<std::string> attr_value = _tree->access<std::vector<std::string>>(mb_root(mboard) / "gpio" / bank / attr).get();
-                         UHD_ASSERT_THROW(attr_value.size() <= 32);
+                        auto attr_value =
+                            _tree->access<std::vector<std::string>>(
+                                mb_root(mboard) / "gpio" / bank / attr).get();
+                        UHD_ASSERT_THROW(attr_value.size() <= 32);
                         std::bitset<32> bit_mask = std::bitset<32>(mask);
-                        for (size_t i = 0 ; i < bit_mask.size(); i++){
-                            if (bit_mask[i] == 1){
-                                 attr_value[i] = str_value;
-                             }
-                         }
-                         _tree->access<std::vector<std::string>>(mb_root(mboard) / "gpio" / bank / attr).set(attr_value);
-                     }
-                        break;
-                    default:{
-                        uint32_t value = gpio_atr::gpio_attr_value_pair.at(attr).at(str_value) == 0 ? -1 : 0;
-                        const uint32_t current = _tree->access<uint32_t>(mb_root(mboard) / "gpio" / bank / attr).get();
-                        const uint32_t new_value = (current & ~mask) | (value & mask);
-                        _tree->access<uint32_t>(mb_root(mboard) / "gpio" / bank / attr).set(new_value);
+                        for (size_t i = 0 ; i < bit_mask.size(); i++) {
+                            if (bit_mask[i] == 1) {
+                                attr_value[i] = str_value;
+                            }
+                        }
+                        _tree->access<std::vector<std::string>>(
+                               mb_root(mboard) / "gpio" / bank / attr
+                        ).set(attr_value);
                     }
-                        break;
+                    break;
+                    default: {
+                        const uint32_t value =
+                            gpio_atr::gpio_attr_value_pair.at(attr).at(str_value) == 0 ? -1 : 0;
+                        const uint32_t current = _tree->access<uint32_t>(
+                            mb_root(mboard) / "gpio" / bank / attr).get();
+                        const uint32_t new_value =
+                            (current & ~mask) | (value & mask);
+                        _tree->access<uint32_t>(
+                            mb_root(mboard) / "gpio" / bank / attr
+                        ).set(new_value);
+                    }
+                    break;
                 }
                 return;
-            }else{
-                throw uhd::runtime_error(str(boost::format(
-                    "The hardware has no gpio attribute: %s:\n") % attr));
+            } else {
+                throw uhd::runtime_error(str(
+                    boost::format("The hardware has no gpio attribute `%s'")
+                    % attr
+                ));
             }
         }
-        if (bank.size() > 2 and bank[1] == 'X')
-        {
-            uint32_t value = gpio_atr::gpio_attr_value_pair.at(attr).at(str_value) == 0 ? -1 : 0;
-            const std::string name = bank.substr(2);
-            const dboard_iface::unit_t unit = (bank[0] == 'R')? dboard_iface::UNIT_RX : dboard_iface::UNIT_TX;
-            dboard_iface::sptr iface = _tree->access<dboard_iface::sptr>(mb_root(mboard) / "dboards" / name / "iface").get();
-            if (attr == gpio_atr::gpio_attr_map.at(gpio_atr::GPIO_CTRL))    iface->set_pin_ctrl(unit, uint16_t(value), uint16_t(mask));
-            if (attr == gpio_atr::gpio_attr_map.at(gpio_atr::GPIO_DDR))     iface->set_gpio_ddr(unit, uint16_t(value), uint16_t(mask));
-            if (attr == gpio_atr::gpio_attr_map.at(gpio_atr::GPIO_OUT))     iface->set_gpio_out(unit, uint16_t(value), uint16_t(mask));
-            if (attr == gpio_atr::gpio_attr_map.at(gpio_atr::GPIO_ATR_0X))  iface->set_atr_reg(unit, gpio_atr::ATR_REG_IDLE, uint16_t(value), uint16_t(mask));
-            if (attr == gpio_atr::gpio_attr_map.at(gpio_atr::GPIO_ATR_RX))  iface->set_atr_reg(unit, gpio_atr::ATR_REG_RX_ONLY, uint16_t(value), uint16_t(mask));
-            if (attr == gpio_atr::gpio_attr_map.at(gpio_atr::GPIO_ATR_TX))  iface->set_atr_reg(unit, gpio_atr::ATR_REG_TX_ONLY, uint16_t(value), uint16_t(mask));
-            if (attr == gpio_atr::gpio_attr_map.at(gpio_atr::GPIO_ATR_XX))  iface->set_atr_reg(unit, gpio_atr::ATR_REG_FULL_DUPLEX, uint16_t(value), uint16_t(mask));
-            if (attr == gpio_atr::gpio_attr_map.at(gpio_atr::GPIO_SRC)){
-                throw uhd::runtime_error("Setting gpio source does not supported in daughter board.");
-            }
-            return;
-        }
-        throw uhd::runtime_error(str(boost::format("The hardware has no gpio bank: %s:\n") % bank));
+        // If the bank is not in the prop tree, convert string value to integer
+        // value and have it handled by the other set_gpio_attr()
+        const uint32_t value =
+            gpio_atr::gpio_attr_value_pair.at(attr).at(str_value) == 0
+            ? -1
+            : 0;
+        set_gpio_attr(
+            bank,
+            attr,
+            value,
+            mask,
+            mboard
+        );
     }
 
-    uint32_t get_gpio_attr(const std::string &bank, const std::string &attr, const size_t mboard)
-    {
+    uint32_t get_gpio_attr(
+            const std::string &bank,
+            const std::string &attr,
+            const size_t mboard
+    ) {
         std::vector<std::string> str_val;
 
-        if (_tree->exists(mb_root(mboard) / "gpio" / bank))
-        {
-            if (_tree->exists(mb_root(mboard) / "gpio" / bank / attr)){
-                gpio_atr::gpio_attr_t attr_type = gpio_atr::gpio_attr_rev_map.at(attr);
+        if (_tree->exists(mb_root(mboard) / "gpio" / bank)) {
+            if (_tree->exists(mb_root(mboard) / "gpio" / bank / attr)) {
+                const auto attr_type = gpio_atr::gpio_attr_rev_map.at(attr);
                 switch (attr_type){
                     case gpio_atr::GPIO_SRC:
-                        throw uhd::runtime_error("Can't set SRC  attribute using u32int_t value");
+                        throw uhd::runtime_error("Can't set SRC attribute using integer value");
                     case gpio_atr::GPIO_CTRL:
-                    case gpio_atr::GPIO_DDR:{
-                        str_val = _tree->access<std::vector<std::string>>(mb_root(mboard) / "gpio" / bank / attr).get();
+                    case gpio_atr::GPIO_DDR: {
+                        str_val = _tree->access<std::vector<std::string>>(
+                            mb_root(mboard) / "gpio" / bank / attr).get();
                         uint32_t val = 0;
-                        for(size_t i = 0 ; i < str_val.size() ; i++){
-                                val += usrp::gpio_atr::gpio_attr_value_pair.at(attr).at(str_val[i])<<i;
+                        for(size_t i = 0 ; i < str_val.size() ; i++) {
+                            val += usrp::gpio_atr::gpio_attr_value_pair.at(attr).at(str_val[i]) << i;
                         }
                         return val;
                     }
-                    default:{
-                        return uint32_t(_tree->access<uint64_t>(mb_root(mboard) / "gpio" / bank / attr).get());
-                    }
+                    default:
+                        return uint32_t(_tree->access<uint64_t>(
+                            mb_root(mboard) / "gpio" / bank / attr).get());
                 }
                 return 0;
-            }else{
-                throw uhd::runtime_error(str(boost::format("The hardware has no gpio attribute: %s:\n") % attr));
+            } else {
+                throw uhd::runtime_error(str(
+                    boost::format("The hardware has no gpio attribute: `%s'")
+                    % attr
+                ));
             }
         }
-        if (bank.size() > 2 and bank[1] == 'X')
-        {
+        if (bank.size() > 2 and bank[1] == 'X') {
             const std::string name = bank.substr(2);
             const dboard_iface::unit_t unit = (bank[0] == 'R')? dboard_iface::UNIT_RX : dboard_iface::UNIT_TX;
-            dboard_iface::sptr iface = _tree->access<dboard_iface::sptr>(mb_root(mboard) / "dboards" / name / "iface").get();
+            auto iface = _tree->access<dboard_iface::sptr>(
+                mb_root(mboard) / "dboards" / name / "iface").get();
             if (attr == "CTRL")     return iface->get_pin_ctrl(unit);
             if (attr == "DDR")      return iface->get_gpio_ddr(unit);
             if (attr == "OUT")      return iface->get_gpio_out(unit);
@@ -2023,24 +2075,28 @@ public:
             if (attr == "ATR_XX")   return iface->get_atr_reg(unit, gpio_atr::ATR_REG_FULL_DUPLEX);
             if (attr == "READBACK") return iface->read_gpio(unit);
         }
-        throw uhd::runtime_error(str(boost::format("The hardware has no gpio bank: %s:\n") % bank));
+        throw uhd::runtime_error(str(
+            boost::format("The hardware has no gpio bank `%s'")
+            % bank
+        ));
     }
-    std::vector<std::string> get_gpio_string_attr(const std::string &bank, const std::string &attr, const size_t mboard)
-    {
-        gpio_atr::gpio_attr_t attr_type = gpio_atr::gpio_attr_rev_map.at(attr);
-        std::vector<std::string> str_val = std::vector<std::string>(32, gpio_atr::default_attr_value_map.at(attr_type));
-        if (_tree->exists(mb_root(mboard) / "gpio" / bank))
-        {
-            if (_tree->exists(mb_root(mboard) / "gpio" / bank / attr))
-            {
-                gpio_atr::gpio_attr_t attr_type = gpio_atr::gpio_attr_rev_map.at(attr);
+
+    std::vector<std::string> get_gpio_string_attr(
+        const std::string &bank,
+        const std::string &attr,
+        const size_t mboard
+    ) {
+        const auto attr_type = gpio_atr::gpio_attr_rev_map.at(attr);
+        auto str_val = std::vector<std::string>(32, gpio_atr::default_attr_value_map.at(attr_type));
+        if (_tree->exists(mb_root(mboard) / "gpio" / bank)) {
+            if (_tree->exists(mb_root(mboard) / "gpio" / bank / attr)) {
+                const auto attr_type = gpio_atr::gpio_attr_rev_map.at(attr);
                 switch (attr_type){
                     case gpio_atr::GPIO_SRC:
                     case gpio_atr::GPIO_CTRL:
-                    case gpio_atr::GPIO_DDR:{
+                    case gpio_atr::GPIO_DDR:
                         return _tree->access<std::vector<std::string>>(mb_root(mboard) / "gpio" / bank / attr).get();
-                    }
-                    default:{
+                    default: {
                         uint32_t value = uint32_t(_tree->access<uint32_t>(mb_root(mboard) / "gpio" / bank / attr).get());
                         std::bitset<32> bit_value = std::bitset<32>(value);
                         for (size_t i = 0; i < bit_value.size(); i++)
@@ -2051,13 +2107,19 @@ public:
                     }
                 }
             }
-            else
-            {
-                throw uhd::runtime_error(str(boost::format("The hardware has no gpio attribute: %s:\n") % attr));
+            else {
+                throw uhd::runtime_error(str(
+                    boost::format("The hardware has no gpio attribute: `%s'")
+                    % attr
+                ));
             }
         }
-        throw uhd::runtime_error(str(boost::format("The hardware has no support for given gpio bank name: %s:\n") % bank));
+        throw uhd::runtime_error(str(
+            boost::format("The hardware has no support for given gpio bank name `%s'")
+            % bank
+        ));
     }
+
     void write_register(const std::string &path, const uint32_t field, const uint64_t value, const size_t mboard)
     {
         if (_tree->exists(mb_root(mboard) / "registers"))
@@ -2413,14 +2475,5 @@ multi_usrp::~multi_usrp(void){
  **********************************************************************/
 multi_usrp::sptr multi_usrp::make(const device_addr_t &dev_addr){
     UHD_LOGGER_TRACE("MULTI_USRP") << "multi_usrp::make with args " << dev_addr.to_pp_string() ;
-
-    // This is where the code branches off to the Crimson implementation.
-    // The instantiation of multi_usrp_impl will throw an error, when no USRP device is found.
-    // This also means that you cannot support both Crimson and USRP devices within the same
-    // network hub.
-    try {
-        return sptr(new multi_usrp_impl(dev_addr));
-    } catch (...) {
-	   return sptr(new multi_crimson_tng(dev_addr));
-    }
+    return sptr(new multi_usrp_impl(dev_addr));
 }


### PR DESCRIPTION
Combine multi_crimson_tng.cpp into multi_usrp.cpp
    
In the future, we should switch to 100% reuse of multi_usrp.cpp. For the time being, we have overwritten the upstream ettus methods for setting & getting frequency and gain with our own.

However, most of that business logic should go on the server eventually. We should be able to copy the code as is, more or less, if we use c++ for the server.
    
Some notable achievements:
    
* fixed a circular reference in crimson_tng_tx_streamer which allowed us to hit that destructor properly.
* added a few more properties in crimson_tng_impl.cpp that let us become closer to parity with upstream ettus
* in the future, we should still break out gain elements into individual properties as well as frequency elements (lo's & nco offsets).
* we also got rid of some of the questionable hacks to turn off the channels from before when the destructor was not properly called.
* destructors are called properly through uhd api and python api
* gnu radio still wasn't destroying our objects properly, so I added another hack to switch off the allocated channels when the process exits.
