### PR TITLE
Stacked TX command proper fix

### DIFF
--- a/host/examples/CMakeLists.txt
+++ b/host/examples/CMakeLists.txt
@@ -19,6 +19,7 @@ SET(example_sources
     test_messages.cpp
     test_pps_input.cpp
     test_timed_commands.cpp
+    test_stacked_gpio_commands.cpp
     tx_bursts.cpp
     tx_samples_from_file.cpp
     tx_timed_samples.cpp

--- a/host/examples/test_stacked_gpio_commands.cpp
+++ b/host/examples/test_stacked_gpio_commands.cpp
@@ -1,0 +1,34 @@
+#include <uhd/utils/thread.hpp>
+#include <uhd/utils/safe_main.hpp>
+#include <uhd/usrp/multi_usrp.hpp>
+
+namespace gpio
+{
+    void write(uhd::usrp::multi_usrp::sptr& usrp, const uint64_t pins, const uint64_t mask, const double time)
+    {
+        usrp->set_command_time(uhd::time_spec_t(time));
+        usrp->set_user_register(0, (uint32_t) (pins >> 0x00)); // Lower first.
+        usrp->set_user_register(1, (uint32_t) (pins >> 0x20)); // Then upper.
+        usrp->set_user_register(2, (uint32_t) (mask >> 0x00)); // Same goes for the mask.
+        usrp->set_user_register(3, (uint32_t) (mask >> 0x20));
+    }
+}
+
+int UHD_SAFE_MAIN(int argc, char *argv[])
+{
+    (void) argc;
+    (void) argv;
+
+    uhd::set_thread_priority_safe();
+
+    uhd::usrp::multi_usrp::sptr usrp = uhd::usrp::multi_usrp::make(std::string(""));
+
+    usrp->set_time_now(uhd::time_spec_t(0.0));
+
+    uint64_t pins = 0x0;
+    const uint64_t all = 0xFFFFFFFFFF;
+    for(double time = 0.0; time < 64.0; time++)
+        gpio::write(usrp, pins ^= all, all, time);
+
+    return 0;
+}

--- a/host/lib/transport/super_send_packet_handler.hpp
+++ b/host/lib/transport/super_send_packet_handler.hpp
@@ -249,7 +249,9 @@ public:
 #ifdef UHD_TXRX_DEBUG_PRINTS
 			dbg_print_send(nsamps_per_buff, nsamps_sent, metadata, timeout);
 #endif
-			return nsamps_sent;        }
+			return nsamps_sent;
+        }
+
         size_t total_num_samps_sent = 0;
 
         //false until final fragment
@@ -262,13 +264,10 @@ public:
         for (size_t i = 0; i < num_fragments; i++){
 
             //send a fragment with the helper function
-            const size_t num_samps_sent = send_one_packet(
-                buffs, _max_samples_per_packet,
-                if_packet_info, timeout,
-                total_num_samps_sent*_bytes_per_cpu_item
-            );
+            const size_t num_samps_sent = send_one_packet(buffs, _max_samples_per_packet, if_packet_info, timeout, total_num_samps_sent*_bytes_per_cpu_item);
             total_num_samps_sent += num_samps_sent;
-            if (num_samps_sent == 0) return total_num_samps_sent;
+            if (num_samps_sent == 0)
+                return total_num_samps_sent;
 
             //setup metadata for the next fragment
             const time_spec_t time_spec = metadata.time_spec; // + time_spec_t::from_ticks(total_num_samps_sent, _samp_rate);
@@ -279,12 +278,10 @@ public:
 
         //send the final fragment with the helper function
         if_packet_info.eob = metadata.end_of_burst;
-		size_t nsamps_sent = total_num_samps_sent
-				+ send_one_packet(buffs, final_length, if_packet_info, timeout,
-					total_num_samps_sent * _bytes_per_cpu_item);
+		size_t nsamps_sent = total_num_samps_sent + send_one_packet(buffs, final_length, if_packet_info, timeout, total_num_samps_sent * _bytes_per_cpu_item);
+
 #ifdef UHD_TXRX_DEBUG_PRINTS
 		dbg_print_send(nsamps_per_buff, nsamps_sent, metadata, timeout);
-
 #endif
 		return nsamps_sent;
     }
@@ -371,7 +368,6 @@ private:
         const double timeout,
         const size_t buffer_offset_bytes = 0
     ){
-
         //load the rest of the if_packet_info in here
         if_packet_info.num_payload_bytes = nsamps_per_buff*_num_inputs*_bytes_per_otw_item;
         if_packet_info.num_payload_words32 = (if_packet_info.num_payload_bytes + 3/*round up*/)/sizeof(uint32_t);

--- a/host/lib/usrp/crimson_tng/crimson_tng_impl.cpp
+++ b/host/lib/usrp/crimson_tng/crimson_tng_impl.cpp
@@ -312,6 +312,12 @@ void crimson_tng_impl::set_user_reg(const std::string key, user_reg_t value) {
         pkt.pins = pins;
         pkt.mask = mask;
 
+        boost::endian::native_to_big_inplace(pkt.header);
+        boost::endian::native_to_big_inplace((uint64_t&) pkt.tv_sec);
+        boost::endian::native_to_big_inplace((uint64_t&) pkt.tv_psec);
+        boost::endian::native_to_big_inplace((uint64_t&) pkt.pins);
+        boost::endian::native_to_big_inplace((uint64_t&) pkt.mask);
+
         std::printf(
             "SHIPPING(set_user_reg):\n"
             "0x%016lX\n"
@@ -319,12 +325,6 @@ void crimson_tng_impl::set_user_reg(const std::string key, user_reg_t value) {
             "0x%016lX\n"
             "0x%016lX\n"
             "0x%016lX\n", pkt.header, pkt.tv_sec, pkt.tv_psec, pkt.pins, pkt.mask);
-
-        boost::endian::native_to_big_inplace((uint64_t&) pkt.header);
-        boost::endian::native_to_big_inplace((uint64_t&) pkt.tv_sec);
-        boost::endian::native_to_big_inplace((uint64_t&) pkt.tv_psec);
-        boost::endian::native_to_big_inplace((uint64_t&) pkt.pins);
-        boost::endian::native_to_big_inplace((uint64_t&) pkt.mask);
 
         std::cout << "GPIO packet size: " << sizeof(pkt) << " bytes" << std::endl;
 

--- a/host/lib/usrp/crimson_tng/crimson_tng_impl.cpp
+++ b/host/lib/usrp/crimson_tng/crimson_tng_impl.cpp
@@ -282,22 +282,23 @@ void crimson_tng_impl::set_user_reg(const std::string key, user_reg_t value) {
     (void) key;
 
     const uint8_t  address = value.first;
-    const uint32_t setting = value.second;
+    const uint64_t setting = value.second;
 
     static uint64_t pins = 0x0;
     static uint64_t mask = 0x0;
 
     // Clearing.
-    if(address == 0) pins &= ~(((uint64_t) 0xFFFFFFFF) << 0x00);
-    if(address == 1) pins &= ~(((uint64_t) 0xFFFFFFFF) << 0x20);
-    if(address == 2) mask &= ~(((uint64_t) 0xFFFFFFFF) << 0x00);
-    if(address == 3) mask &= ~(((uint64_t) 0xFFFFFFFF) << 0x20);
+    const uint64_t all = 0xFFFFFFFF;
+    if(address == 0) pins &= ~(all << 0x00);
+    if(address == 1) pins &= ~(all << 0x20);
+    if(address == 2) mask &= ~(all << 0x00);
+    if(address == 3) mask &= ~(all << 0x20);
 
     // Setting.
-    if(address == 0) pins |= (((uint64_t) setting) << 0x00);
-    if(address == 1) pins |= (((uint64_t) setting) << 0x20);
-    if(address == 2) mask |= (((uint64_t) setting) << 0x00);
-    if(address == 3) mask |= (((uint64_t) setting) << 0x20);
+    if(address == 0) pins |= (setting << 0x00);
+    if(address == 1) pins |= (setting << 0x20);
+    if(address == 2) mask |= (setting << 0x00);
+    if(address == 3) mask |= (setting << 0x20);
 
     if(address > 3)
         std::cout << "UHD: WARNING: User defined registers [4:256] not defined" << std::endl;
@@ -312,19 +313,19 @@ void crimson_tng_impl::set_user_reg(const std::string key, user_reg_t value) {
         pkt.pins = pins;
         pkt.mask = mask;
 
+        std::printf(
+            "SHIPPING(set_user_reg):\n"
+            "0x%016llX\n"
+            "0x%016llX\n"
+            "0x%016llX\n"
+            "0x%016llX\n"
+            "0x%016llX\n", pkt.header, pkt.tv_sec, pkt.tv_psec, pkt.pins, pkt.mask);
+
         boost::endian::native_to_big_inplace(pkt.header);
         boost::endian::native_to_big_inplace((uint64_t&) pkt.tv_sec);
         boost::endian::native_to_big_inplace((uint64_t&) pkt.tv_psec);
         boost::endian::native_to_big_inplace((uint64_t&) pkt.pins);
         boost::endian::native_to_big_inplace((uint64_t&) pkt.mask);
-
-        std::printf(
-            "SHIPPING(set_user_reg):\n"
-            "0x%016lX\n"
-            "0x%016lX\n"
-            "0x%016lX\n"
-            "0x%016lX\n"
-            "0x%016lX\n", pkt.header, pkt.tv_sec, pkt.tv_psec, pkt.pins, pkt.mask);
 
         std::cout << "GPIO packet size: " << sizeof(pkt) << " bytes" << std::endl;
 

--- a/host/lib/usrp/crimson_tng/flow_control_nonlinear.hpp
+++ b/host/lib/usrp/crimson_tng/flow_control_nonlinear.hpp
@@ -140,6 +140,7 @@ public:
 			buffer_level_set_time = now;
 		}
 
+#define DEBUG_FLOW_CONTROL
 #ifdef DEBUG_FLOW_CONTROL
 		// underflow
 		if ( BOOST_UNLIKELY( buffer_level < 0 ) ) {

--- a/host/lib/usrp/crimson_tng/flow_control_nonlinear.hpp
+++ b/host/lib/usrp/crimson_tng/flow_control_nonlinear.hpp
@@ -119,6 +119,7 @@ public:
                 dt = sob_time - now;
             }
         } else {
+
             bl = unlocked_get_buffer_level( now );
             dt = ( bl - (double)nominal_buffer_level ) / nominal_sample_rate;
         }

--- a/host/lib/usrp/crimson_tng/io_impl.cpp
+++ b/host/lib/usrp/crimson_tng/io_impl.cpp
@@ -45,10 +45,10 @@
 #include "system_time.hpp"
 
 #ifndef UHD_TXRX_DEBUG_PRINTS
-//#define UHD_TXRX_DEBUG_PRINTS
+#define UHD_TXRX_DEBUG_PRINTS
 #endif
 #ifndef UHD_TXRX_SEND_DEBUG_PRINTS
-//#define UHD_TXRX_SEND_DEBUG_PRINTS
+#define UHD_TXRX_SEND_DEBUG_PRINTS
 #endif
 
 using namespace uhd;
@@ -236,15 +236,14 @@ public:
                 metadata.time_spec = now + default_sob;
             }
         }
-#define UHD_TXRX_DEBUG_PRINTS_TIMING
         if ( metadata.start_of_burst ) {
             if ( metadata.time_spec < now + default_sob ) {
                 metadata.time_spec = now + default_sob;
-                #ifdef UHD_TXRX_DEBUG_PRINTS_TIMING
+                #ifdef UHD_TXRX_DEBUG_PRINTS
                 std::cout << "UHD::CRIMSON_TNG::Warning: time_spec was too soon for start of burst and has been adjusted!" << std::endl;
                 #endif
             }
-            #ifdef UHD_TXRX_DEBUG_PRINTS_TIMING
+            #ifdef UHD_TXRX_DEBUG_PRINTS
             std::cout << "UHD::CRIMSON_TNG::Info: " << get_time_now() << ": sob @ " << metadata.time_spec << " | " << metadata.time_spec.to_ticks( 162500000 ) << std::endl;
             #endif
             for( auto & ep: _eprops ) {
@@ -277,7 +276,7 @@ public:
         now = get_time_now();
 
         if ( 0 == nsamps_per_buff && metadata.end_of_burst ) {
-            #ifdef UHD_TXRX_DEBUG_PRINTS_TIMING
+            #ifdef UHD_TXRX_DEBUG_PRINTS
             std::cout << "UHD::CRIMSON_TNG::Info: " << now << ": " << "eob @ " << now << " | " << now.to_ticks( 162500000 ) << std::endl;
             #endif
 


### PR DESCRIPTION
I modified the generate waveform example (examples/tx_waveforms.cpp) to loop with different start of burst times. Turns out, between success start of burst commands, the flow control buffer level was not being reset. This fix works out to be:
```
            for( auto & ep: _eprops ) {
                ep.flow_control->set_buffer_level(0, get_time_now());
            }
```
See line 367 in pillage() in host/lib/usrp/crimson_tng/crimson_tng_impl.cpp
