### PR TITLE
Disabled debug prints originally from master-testing

### DIFF
--- a/host/lib/usrp/crimson_tng/io_impl.cpp
+++ b/host/lib/usrp/crimson_tng/io_impl.cpp
@@ -44,11 +44,13 @@
 
 #include "system_time.hpp"
 
-#ifndef UHD_TXRX_DEBUG_PRINTS
-#define UHD_TXRX_DEBUG_PRINTS
-#endif
-#ifndef UHD_TXRX_SEND_DEBUG_PRINTS
-#define UHD_TXRX_SEND_DEBUG_PRINTS
+#if 0
+  #ifndef UHD_TXRX_DEBUG_PRINTS
+  #define UHD_TXRX_DEBUG_PRINTS
+  #endif
+  #ifndef UHD_TXRX_SEND_DEBUG_PRINTS
+  #define UHD_TXRX_SEND_DEBUG_PRINTS
+  #endif
 #endif
 
 using namespace uhd;


### PR DESCRIPTION
The pull from master-testing to master did not account for debug prints which intentionally slow down printouts (and coincidentally) the update speed of the buffer manager.

This PR disables the debug prints.