### PR TITLE
 Mutex Fix + Nanosleep fc_condition underrun Fix + Viking Loop Delay Fix

### DIFF
--- a/host/lib/usrp/crimson_tng/crimson_tng_impl.hpp
+++ b/host/lib/usrp/crimson_tng/crimson_tng_impl.hpp
@@ -100,11 +100,21 @@ public:
     uhd::device_addr_t device_addr;
 
     uhd::time_spec_t get_time_now() {
-    	double diff = time_diff_get();
+        double diff = time_diff_get();
         return uhd::get_system_time() + diff;
     }
-    inline double time_diff_get() { return _time_diff; }
-    inline void time_diff_set( double time_diff ) { _time_diff = time_diff; }
+
+    std::mutex _time_diff_mutex;
+
+    inline double time_diff_get() {
+        std::lock_guard<std::mutex> _lock( _time_diff_mutex );
+        return _time_diff;
+    }
+    inline void time_diff_set( double time_diff ) {
+        std::lock_guard<std::mutex> _lock( _time_diff_mutex );
+        _time_diff = time_diff;
+    }
+
     bool time_diff_converged();
     void start_bm();
     void stop_bm();

--- a/host/lib/usrp/crimson_tng/flow_control_nonlinear.hpp
+++ b/host/lib/usrp/crimson_tng/flow_control_nonlinear.hpp
@@ -9,6 +9,10 @@
 #include "flow_control.hpp"
 #include "sma.hpp"
 
+#if 0
+#define DEBUG_FLOW_CONTROL
+#endif
+
 namespace uhd {
 
 class flow_control_nonlinear: virtual uhd::flow_control {
@@ -141,7 +145,6 @@ public:
 			buffer_level_set_time = now;
 		}
 
-#define DEBUG_FLOW_CONTROL
 #ifdef DEBUG_FLOW_CONTROL
 		// underflow
 		if ( BOOST_UNLIKELY( buffer_level < 0 ) ) {

--- a/host/lib/usrp/crimson_tng/io_impl.cpp
+++ b/host/lib/usrp/crimson_tng/io_impl.cpp
@@ -44,11 +44,13 @@
 
 #include "system_time.hpp"
 
-#ifndef UHD_TXRX_DEBUG_PRINTS
-#define UHD_TXRX_DEBUG_PRINTS
-#endif
-#ifndef UHD_TXRX_SEND_DEBUG_PRINTS
-#define UHD_TXRX_SEND_DEBUG_PRINTS
+#if 0
+  #ifndef UHD_TXRX_DEBUG_PRINTS
+  #define UHD_TXRX_DEBUG_PRINTS
+  #endif
+  #ifndef UHD_TXRX_SEND_DEBUG_PRINTS
+  #define UHD_TXRX_SEND_DEBUG_PRINTS
+  #endif
 #endif
 
 using namespace uhd;

--- a/host/lib/usrp/crimson_tng/io_impl.cpp
+++ b/host/lib/usrp/crimson_tng/io_impl.cpp
@@ -203,7 +203,7 @@ public:
     ){
         static const double default_sob = 1.0;
 
-        size_t r;
+        size_t r = 0;
 
         uhd::tx_metadata_t metadata = metadata_;
 
@@ -224,9 +224,9 @@ public:
                 #endif
                 metadata.start_of_burst = true;
 
-        		//for( auto & ep: _eprops ) {
-        		//	ep._remaining_num_samps = 0;
-        		//}
+				//for( auto & ep: _eprops ) {
+				//	ep._remaining_num_samps = 0;
+				//}
             }
         }
         if ( _first_call_to_send ) {
@@ -273,7 +273,7 @@ public:
 
            // ep.buffer_mutex.lock();
 			//if (ep._remaining_num_samps <=0) ep._remaining_num_samps = nsamps_per_buff;
-	       // ep.buffer_mutex.unlock();
+		   // ep.buffer_mutex.unlock();
       //  }
 
         now = get_time_now();
@@ -314,7 +314,7 @@ public:
     }
 
     void set_on_fini( size_t chan, onfini_type on_fini ) {
-    	_eprops.at(chan).on_fini = on_fini;
+		_eprops.at(chan).on_fini = on_fini;
     }
     void set_time_now( timenow_type time_now ) {
         _time_now = time_now;
@@ -323,13 +323,13 @@ public:
         return _time_now ? _time_now() : get_system_time();
     }
     void set_xport_chan( size_t chan, uhd::transport::zero_copy_if::sptr xport ) {
-    	_eprops.at(chan).xport_chan = xport;
+		_eprops.at(chan).xport_chan = xport;
     }
     void set_xport_chan_fifo_lvl( size_t chan, xport_chan_fifo_lvl_type get_fifo_lvl ) {
-    	_eprops.at(chan).xport_chan_fifo_lvl = get_fifo_lvl;
+		_eprops.at(chan).xport_chan_fifo_lvl = get_fifo_lvl;
     }
     void set_async_pusher( async_pusher_type pusher ) {
-    	async_pusher = pusher;
+		async_pusher = pusher;
     }
     void set_channel_name( size_t chan, std::string name ) {
         _eprops.at(chan).name = name;
@@ -341,7 +341,7 @@ public:
 			ep.flow_control = uhd::flow_control_nonlinear::make( 1.0, 0.8, CRIMSON_TNG_BUFF_SIZE );
 			ep.flow_control->set_buffer_level( 0, get_time_now() );
 		}
-    	sph::send_packet_handler::resize(size);
+		sph::send_packet_handler::resize(size);
     }
 
     void set_samp_rate(const double rate){
@@ -401,12 +401,12 @@ private:
 
     // extended per-channel properties, beyond what is available in sph::send_packet_handler::xport_chan_props_type
     struct eprops_type{
-    	onfini_type on_fini;
-    	uhd::transport::zero_copy_if::sptr xport_chan;
-    	xport_chan_fifo_lvl_type xport_chan_fifo_lvl;
-    	uhd::flow_control::sptr flow_control;
-    	uint64_t oflow;
-    	uint64_t uflow;
+		onfini_type on_fini;
+		uhd::transport::zero_copy_if::sptr xport_chan;
+		xport_chan_fifo_lvl_type xport_chan_fifo_lvl;
+		uhd::flow_control::sptr flow_control;
+		uint64_t oflow;
+		uint64_t uflow;
         size_t _remaining_num_samps;
         std::mutex buffer_mutex;
         std::string name;
@@ -423,13 +423,13 @@ private:
     std::vector<eprops_type> _eprops;
 
     void push_async_msg( uhd::async_metadata_t &async_metadata ){
-    	if ( async_pusher ) {
-    		async_pusher( async_metadata );
-    	}
+		if ( async_pusher ) {
+			async_pusher( async_metadata );
+		}
     }
 
     void check_fc_update( const size_t chan, size_t nsamps) {
-    	_eprops.at( chan ).buffer_mutex.lock();
+		_eprops.at( chan ).buffer_mutex.lock();
         _eprops.at( chan ).flow_control->update( nsamps, get_time_now() );
 		_eprops.at( chan ).buffer_mutex.unlock();
     }
@@ -461,21 +461,15 @@ private:
 		}
 		#endif
 
-		for(
-			;
-			dt > 0.0001;
-			now = get_time_now(),
-				dt = then - now
-		) {
-			dt = dt - 0.0001;
-			req.tv_sec = (time_t) dt.get_full_secs();
-			req.tv_nsec = dt.get_frac_secs()*1e9;
-			nanosleep( &req, &rem );
-		}
-		//Nop loop for finer accuracy
-		while (then-get_time_now() > 0.0){
-			static_cast<void> (0);
-		}
+		// The time delta (dt) may be negative from the linear interpolator.
+		// In such a case, do not bother with the delay calculations and send right away.
+		if(dt <= 0.0)
+			return true;
+
+		// Otherwise, delay.
+		req.tv_sec = (time_t) dt.get_full_secs();
+		req.tv_nsec = dt.get_frac_secs()*1e9;
+		nanosleep( &req, &rem );
 
 		return true;
     }
@@ -493,7 +487,11 @@ private:
 		// std::cout << __func__ << "(): beginning viking loop for tx streamer @ " << (void *) self << std::endl;
 
 		for( ; ! self->_blessbless; ) {
+
+			const auto t0 = std::chrono::high_resolution_clock::now();
+
 			for( size_t i = 0; i < self->_eprops.size(); i++ ) {
+
 				eprops_type & ep = self->_eprops[ i ];
 
 				xport_chan_fifo_lvl_type get_fifo_level;
@@ -517,6 +515,11 @@ private:
 				try {
 					get_fifo_level( level_pcnt, uflow, oflow, then );
 				} catch( ... ) {
+
+#define DEBUG_FC
+#ifdef DEBUG_FC
+				std::printf("%10d\t", -1);
+#endif
 					continue;
 				}
 
@@ -531,13 +534,17 @@ private:
 				if ( ! fc->start_of_burst_pending( then ) ) {
 					level -= ( now - then ).get_real_secs() / self->_samp_rate;
 					fc->set_buffer_level( level, now );
+#ifdef DEBUG_FC
+				std::printf("%10lu\t", level);
+#endif
 				}
-
-
+#ifdef DEBUG_FC
+				std::printf("%10ld\t", uflow);
+#endif
 				if ( (uint64_t)-1 != ep.uflow && uflow != ep.uflow ) {
 					// XXX: @CF: 20170905: Eventually we want to return tx channel metadata as VRT49 context packets rather than custom packets. See usrp2/io_impl.cpp
-		            // async_metadata_t metadata;
-		            // load_metadata_from_buff( uhd::ntohx<boost::uint32_t>, metadata, if_packet_info, vrt_hdr, tick_rate, index );
+					// async_metadata_t metadata;
+					// load_metadata_from_buff( uhd::ntohx<boost::uint32_t>, metadata, if_packet_info, vrt_hdr, tick_rate, index );
 					metadata.channel = i;
 					metadata.has_time_spec = true;
 					metadata.time_spec = then;
@@ -547,10 +554,13 @@ private:
 				}
 				ep.uflow = uflow;
 
+#ifdef DEBUG_FC
+				std::printf("%10ld", oflow);
+#endif
 				if ( (uint64_t)-1 != ep.oflow && oflow != ep.oflow ) {
 					// XXX: @CF: 20170905: Eventually we want to return tx channel metadata as VRT49 context packets rather than custom packets. See usrp2/io_impl.cpp
-		            // async_metadata_t metadata;
-		            // load_metadata_from_buff( uhd::ntohx<boost::uint32_t>, metadata, if_packet_info, vrt_hdr, tick_rate, index );
+					// async_metadata_t metadata;
+					// load_metadata_from_buff( uhd::ntohx<boost::uint32_t>, metadata, if_packet_info, vrt_hdr, tick_rate, index );
 					metadata.channel = i;
 					metadata.has_time_spec = true;
 					metadata.time_spec = then;
@@ -560,10 +570,20 @@ private:
 				}
 				ep.oflow = oflow;
 			}
+
+			const auto t1 = std::chrono::high_resolution_clock::now();
+			const long long us = std::chrono::duration_cast<std::chrono::microseconds>(t1 - t0).count();
+			const long long usloop = 1.0 / (double)CRIMSON_TNG_UPDATE_PER_SEC * 1e6;
+			const long long usdelay = usloop - us;
+
+#ifdef DEBUG_FC
+			std::printf("%10lld %10lld %10lld\n", us, usloop, usdelay);
+#endif
+
 #ifdef UHD_TXRX_DEBUG_PRINTS
 			::usleep( 200000 );
 #else
-			::usleep( 1.0 / (double)CRIMSON_TNG_UPDATE_PER_SEC * 1e6 );
+			::usleep( usdelay < 0 ? 0 : usdelay );
 #endif
 		}
 		//std::cout << __func__ << "(): ending viking loop for tx streamer @ " << (void *) self << std::endl;
@@ -921,13 +941,14 @@ static void get_fifo_lvl_udp( const size_t channel, uhd::transport::udp_simple::
 
 	boost::endian::big_to_native_inplace( req.header );
 
-	size_t r;
+	size_t r = 0;
 
 	for( size_t tries = 0; tries < 1; tries++ ) {
 		r = xport->send( boost::asio::mutable_buffer( & req, sizeof( req ) ) );
 		if ( sizeof( req ) != r ) {
 			continue;
 		}
+
 		r = xport->recv( boost::asio::mutable_buffer( & rsp, sizeof( rsp ) ) );
 		if ( sizeof( rsp ) != r ) {
 			continue;
@@ -1000,7 +1021,7 @@ tx_streamer::sptr crimson_tng_impl::get_tx_stream(const uhd::stream_args_t &args
     crimson_tng_send_packet_streamer::timenow_type timenow_ = boost::bind( & crimson_tng_impl::get_time_now, this );
     std::vector<uhd::transport::zero_copy_if::sptr> xports;
     for( auto & i: args.channels ) {
-    	xports.push_back( _mbc[ _mbc.keys().front() ].tx_dsp_xports[ i ] );
+        xports.push_back( _mbc[ _mbc.keys().front() ].tx_dsp_xports[ i ] );
     }
     boost::shared_ptr<crimson_tng_send_packet_streamer> my_streamer = boost::make_shared<crimson_tng_send_packet_streamer>( spp );
 

--- a/host/lib/usrp/crimson_tng/pidc.hpp
+++ b/host/lib/usrp/crimson_tng/pidc.hpp
@@ -2,7 +2,7 @@
 #define PIDC_HPP_
 
 #ifndef DEBUG_PIDC
-//#define DEBUG_PIDC 1
+#define DEBUG_PIDC 1
 #endif
 
 #ifdef DEBUG_PIDC


### PR DESCRIPTION
This is a three part fix for the flow controller addressing underruns and overruns. The fix is robust, as the primary factor of the flow controller saturating was a race condition between the PID update loop and get_time_now(), but the PID control thread for time_diff can still use a little extra tuning - the occasional divergence still causes TX sequence errors.